### PR TITLE
Handle bad json in token cookie

### DIFF
--- a/app/Strava.py
+++ b/app/Strava.py
@@ -129,7 +129,12 @@ class TokenStorage():
         if (not token):
             return None
 
-        return json.loads(token)
+        try:
+            ret = json.loads(token)
+        except json.decoder.JSONDecodeError:
+            raise AuthenticationException
+
+        return ret
 
 
 class CookieTokenStorage(TokenStorage):


### PR DESCRIPTION
`/debug` (and other) endpoints will crash if bad json is received in the token cookie. This is acceptable for other endpoints, but for `/debug`, we still want to see what data was received in the HTTP header.

So let's handle bad json and raise as an AuthenticationException