### PR TITLE
Add support for redis cache backend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,5 +44,7 @@ jobs:
             --parameter-overrides \
                 StravaClientId=${STRAVA_CLIENT_ID} \
                 StravaClientSecret=${STRAVA_CLIENT_SECRET} \
+                RedisHost=${REDIS_HOST} \
+                RedisPassword=${REDIS_PASSWORD} \
                 EcrImageUri=${IMAGE_URI}:${IMAGE_TAG} \
             --template-file build/sam-template.yaml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This application will first ask to connect to your strava account and will then 
 The application is setup to be built and run within a docker container (tested using orbstack)
 
   * Add strava key and secret to .env
-  * Run `make docker-build` to build the image (currently for dev mode only)
+  * Run `make docker-build-dev` to build the image for dev
   * Run `make docker-run` to start the application in docker, listening on port 8080
   * Run `make open` to open your browser at the charts endpoint of the application
     * Note that this will complain about the self-signed certs

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 ### Strava:
   * [ ] fetch older data asynchronously
   * [ ] allow filtering of activity types
-  * [ ] switch caching to redis (or other distributed store). without it, we can't have concurrency
+  * [x] switch caching to redis (or other distributed store). without it, we can't have concurrency
 
 ### server
   * [ ] clean up handling/parsing of activities

--- a/app/Config.py
+++ b/app/Config.py
@@ -14,29 +14,28 @@ class Config:
             except yaml.YAMLError as e:
                 print("Failed to load config: %s" % e)
 
-        self._getFromEnviron('strava_client_id')
-        self._getFromEnviron('strava_client_secret')
-
     def get(self, key, default=None):
-        return self.config.get(key, default)
+        ret = self.config.get(key, default)
+
+        if isinstance(ret, str) and ret.startswith('[ENV]'):
+            ret = self._getFromEnviron(ret.strip('[ENV]'))
+
+        return ret
 
     def dump(self):
         return self.config
 
-    def _getFromEnviron(self, name: str) -> bool:
+    def _getFromEnviron(self, name: str) -> str:
         """
         Read a config variable from the environment if set
 
         :param name: The name of the environment variable to check for. This is
-                     expected to be in ALL CAPS for the environment variable,
-                     and will be recorded in this name in all lowercase within
-                     this class
+                     expected to be in ALL CAPS for the environment variable
 
-        :return True if an environment variable with the given name was found,
-                False otherwise
+        :return String the value of the value from environment variable, empty
+                string if not found or not set
         """
         if (os.environ[name.upper()]):
-            self.config[name.lower()] = os.environ[name.upper()]
-            return True
+            return os.environ[name.upper()]
 
-        return False
+        return ''

--- a/app/application.py
+++ b/app/application.py
@@ -274,6 +274,7 @@ if ('dev' in sys.argv):
         certfile='cert.crt',
         keyfile='private.key',
         server='gunicorn',
+        timeout=120
     )
 
 

--- a/app/config/dev.yaml
+++ b/app/config/dev.yaml
@@ -1,3 +1,6 @@
+strava_client_id: '[ENV]STRAVA_CLIENT_ID'
+strava_client_secret: '[ENV]STRAVA_CLIENT_SECRET'
 strava_redirect_uri: 'https://localhost:8080/verify'
 cache_ttl: 86400
 max_page_size: 100
+cache_backend: 'sqlite'

--- a/app/config/prod.yaml
+++ b/app/config/prod.yaml
@@ -1,4 +1,10 @@
+strava_client_id: '[ENV]STRAVA_CLIENT_ID'
+strava_client_secret: '[ENV]STRAVA_CLIENT_SECRET'
 strava_redirect_uri: 'https://stravacharts.3thirty.space/verify'
 cache_ttl: 86400
-cache_data_dir: '/tmp'
-cache_backend: 'sqlite'
+cache_backend: 'redis'
+redis_host: '[ENV]REDIS_HOST'
+redis_port: 6379
+redis_username: 'default'
+redis_password: '[ENV]REDIS_PASSWORD'
+redis_ssl: true

--- a/build/sam-template.yaml
+++ b/build/sam-template.yaml
@@ -9,6 +9,10 @@ Parameters:
     Type: String
   StravaClientSecret:
     Type: String
+  RedisHost:
+    Type: String
+  RedisPassword:
+    Type: String
   Debug:
     Type: String
     Default: 0
@@ -24,6 +28,8 @@ Resources:
         Variables:
           STRAVA_CLIENT_ID: !Ref StravaClientId
           STRAVA_CLIENT_SECRET: !Ref StravaClientSecret
+          REDIS_HOST: !Ref RedisHost
+          REDIS_PASSWORD: !Ref RedisPassword
           DEBUG: !Ref Debug
       Events:
         HttpApiEvent:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 requests==2.32.3
-requests-cache==1.2.1
+requests-cache[all]==1.2.1
 requests-oauthlib==2.0.0
 bottle==0.13.2
 bottle-beaker==0.1.3
 PyYAML==6.0.2
 gunicorn==23.0.0
 pyChart.JS==0.3.0
+redis==6.2.0


### PR DESCRIPTION
This PR adds support for Redis cache backend, and enables it for prod.

Note that the production installation (stravacharts.3thirty.space) currently uses an upstash.com hosted redis instance, so that infra is not covered by the SAM template

Also:
  * Adds a mechanism for defining config values as set by env var (`[ENV]env_name`)
  * sqlite support is still maintained