### PR TITLE
Add sport filtering

### DIFF
--- a/app/Activity.py
+++ b/app/Activity.py
@@ -46,6 +46,9 @@ class Activity:
         if ('total_elevation_gain' in d):
             ret.total_elevation_gain = d['total_elevation_gain']
 
+        if ('type' in d):
+            ret.sport = d['type'].lower()
+
         return ret
 
     def getDateTime(self):
@@ -60,7 +63,7 @@ class Activity:
     def getDateHumanReadable(self):
         date = self.getDateTime()
 
-        return(datetime.strftime(date, "%x"))
+        return (datetime.strftime(date, "%x"))
 
     def dump(self):
         out = {
@@ -69,7 +72,9 @@ class Activity:
             'average_speed': getattr(self, 'average_speed', None),
             'distance': getattr(self, 'distance', None),
             'moving_time': getattr(self, 'moving_time', None),
-            'total_elevation_gain': getattr(self, 'total_elevation_gain', None),
+            'total_elevation_gain': getattr(self, 'total_elevation_gain',
+                                            None),
+            'sport': getattr(self, 'sport', None),
         }
         return out
 
@@ -121,6 +126,8 @@ class ActivityList(list):
                         out_total += value
                         out_count += 1
                 except AttributeError:
+                    pass
+                except TypeError:
                     pass
 
             if (out_count > 0):
@@ -240,3 +247,18 @@ class ActivityList(list):
                 out.append(activity)
 
         return out
+
+    def filter(activities: ActivityList, predicate: callable) -> ActivityList:
+        """
+        Filter the given ActivityList to include only items matching the
+        predicate
+
+        :param activities: the ActivityList to filter
+        :param predicate:  callable (lambda) that defines the condition that\
+                           any returned activities must match
+
+        :return ActivityList including only activities matching the predicate
+        """
+        return ActivityList(
+            [activity for activity in activities if predicate(activity)]
+        )

--- a/app/application.py
+++ b/app/application.py
@@ -201,6 +201,11 @@ def chart(type: str = 'average', metric: str = 'average_watts',
     else:
         activities = strava.getAllActivities()
 
+    if (request.query.sport):
+        activities = ActivityList.filter(
+            activities, lambda a: a.sport == request.query.sport
+        )
+
     return _renderChart(type, metric, period, activities)
 
 
@@ -222,6 +227,11 @@ def demo(type: str = 'average', metric: str = 'average_watts',
         activities = strava.getActivities(int(request.query.limit))
     else:
         activities = strava.getAllActivities()
+
+    if (request.query.sport):
+        activities = ActivityList.filter(
+            activities, lambda a: a.sport == request.query.sport
+        )
 
     return _renderChart(type, metric, period, activities)
 

--- a/app/data/demo.json
+++ b/app/data/demo.json
@@ -1,7330 +1,14915 @@
 [
   {
-    "start_date": "2020-04-28T12:34:53Z",
-    "average_watts": 138.3,
-    "average_speed": 3.252,
-    "distance": 4578.2,
-    "moving_time": 1408,
-    "total_elevation_gain": 37.4
+    "start_date": "2020-04-28T19:26:28Z",
+    "average_watts": 158.7,
+    "average_speed": 8.52,
+    "distance": 21769.1,
+    "moving_time": 2555,
+    "total_elevation_gain": 280.6,
+    "type": "Ride"
   },
   {
-    "start_date": "2020-05-01T12:42:31Z",
-    "average_watts": 163.7,
-    "average_speed": 6.507,
-    "distance": 30051.4,
-    "moving_time": 4618,
-    "total_elevation_gain": 283.0
-  },
-  {
-    "start_date": "2020-05-02T13:22:39Z",
-    "average_watts": 153.9,
-    "average_speed": 9.435,
-    "distance": 17105.8,
-    "moving_time": 1813,
-    "total_elevation_gain": 175.3
-  },
-  {
-    "start_date": "2020-05-03T10:40:51Z",
-    "average_watts": 136.2,
-    "average_speed": 5.798,
-    "distance": 84008.5,
-    "moving_time": 14489,
-    "total_elevation_gain": 803.0
-  },
-  {
-    "start_date": "2020-05-05T11:20:31Z",
-    "average_watts": 153.5,
-    "average_speed": 5.516,
-    "distance": 95843.6,
-    "moving_time": 17374,
-    "total_elevation_gain": 1167.9
-  },
-  {
-    "start_date": "2020-05-08T06:20:07Z",
-    "average_watts": 138.5,
-    "average_speed": 6.556,
-    "distance": 71636.3,
-    "moving_time": 10927,
-    "total_elevation_gain": 407.2
-  },
-  {
-    "start_date": "2020-05-09T12:45:55Z",
-    "average_watts": 163.0,
-    "average_speed": 7.899,
-    "distance": 12093.7,
-    "moving_time": 1531,
-    "total_elevation_gain": 97.4
-  },
-  {
-    "start_date": "2020-05-11T14:29:24Z",
-    "average_watts": 139.2,
-    "average_speed": 6.57,
-    "distance": 50907.6,
-    "moving_time": 7748,
-    "total_elevation_gain": 642.6
-  },
-  {
-    "start_date": "2020-05-13T18:40:06Z",
-    "average_watts": 137.1,
-    "average_speed": 3.218,
-    "distance": 5657.3,
-    "moving_time": 1758,
-    "total_elevation_gain": 79.2
-  },
-  {
-    "start_date": "2020-05-19T10:36:02Z",
-    "average_watts": 137.9,
-    "average_speed": 3.298,
-    "distance": 4521.7,
-    "moving_time": 1371,
-    "total_elevation_gain": 67.8
-  },
-  {
-    "start_date": "2020-05-21T10:10:17Z",
+    "start_date": "2020-05-03T16:53:32Z",
     "average_watts": 138.7,
-    "average_speed": 6.841,
-    "distance": 51514.6,
-    "moving_time": 7530,
-    "total_elevation_gain": 744.6
+    "average_speed": 3.5,
+    "distance": 7430.2,
+    "moving_time": 2123,
+    "total_elevation_gain": 100.6,
+    "type": "Ride"
   },
   {
-    "start_date": "2020-05-22T14:34:53Z",
-    "average_watts": 169.9,
-    "average_speed": 7.213,
-    "distance": 20824.7,
-    "moving_time": 2887,
-    "total_elevation_gain": 223.3
-  },
-  {
-    "start_date": "2020-05-23T09:30:43Z",
-    "average_watts": 134.6,
-    "average_speed": 5.107,
-    "distance": 34297.0,
-    "moving_time": 6716,
-    "total_elevation_gain": 425.7
-  },
-  {
-    "start_date": "2020-05-25T13:10:08Z",
-    "average_watts": 133.7,
-    "average_speed": 7.798,
-    "distance": 14894.1,
-    "moving_time": 1910,
-    "total_elevation_gain": 150.6
-  },
-  {
-    "start_date": "2020-05-26T09:05:21Z",
-    "average_watts": 151.3,
-    "average_speed": 6.679,
-    "distance": 90230.3,
-    "moving_time": 13510,
-    "total_elevation_gain": 1082.7
-  },
-  {
-    "start_date": "2020-05-27T13:11:00Z",
-    "average_watts": 143.0,
-    "average_speed": 4.734,
-    "distance": 3588.2,
-    "moving_time": 758,
-    "total_elevation_gain": 52.7
-  },
-  {
-    "start_date": "2020-05-30T15:44:55Z",
-    "average_watts": 167.4,
-    "average_speed": 7.044,
-    "distance": 23077.4,
-    "moving_time": 3276,
-    "total_elevation_gain": 274.3
-  },
-  {
-    "start_date": "2020-05-31T16:07:35Z",
-    "average_watts": 149.4,
-    "average_speed": 6.222,
-    "distance": 51937.6,
-    "moving_time": 8348,
-    "total_elevation_gain": 319.0
-  },
-  {
-    "start_date": "2020-06-02T06:50:42Z",
-    "average_watts": 153.8,
-    "average_speed": 9.929,
-    "distance": 14516.7,
-    "moving_time": 1462,
-    "total_elevation_gain": 185.5
-  },
-  {
-    "start_date": "2020-06-04T17:21:36Z",
-    "average_watts": 162.9,
-    "average_speed": 9.864,
-    "distance": 18405.4,
-    "moving_time": 1866,
-    "total_elevation_gain": 215.1
-  },
-  {
-    "start_date": "2020-06-07T14:21:03Z",
-    "average_watts": 160.6,
-    "average_speed": 8.169,
-    "distance": 16011.9,
-    "moving_time": 1960,
-    "total_elevation_gain": 123.1
-  },
-  {
-    "start_date": "2020-06-08T18:05:40Z",
-    "average_watts": 162.6,
-    "average_speed": 5.864,
-    "distance": 58497.0,
-    "moving_time": 9975,
-    "total_elevation_gain": 427.4
-  },
-  {
-    "start_date": "2020-06-11T19:20:59Z",
-    "average_watts": 161.2,
-    "average_speed": 5.519,
-    "distance": 68230.7,
-    "moving_time": 12362,
-    "total_elevation_gain": 808.4
-  },
-  {
-    "start_date": "2020-06-12T10:34:31Z",
-    "average_watts": 143.4,
-    "average_speed": 7.841,
-    "distance": 29685.1,
-    "moving_time": 3786,
-    "total_elevation_gain": 176.4
-  },
-  {
-    "start_date": "2020-06-13T19:03:23Z",
-    "average_watts": 153.7,
-    "average_speed": 6.665,
-    "distance": 89088.2,
-    "moving_time": 13366,
-    "total_elevation_gain": 998.7
-  },
-  {
-    "start_date": "2020-06-18T09:34:26Z",
-    "average_watts": 144.0,
-    "average_speed": 4.583,
-    "distance": 6109.6,
-    "moving_time": 1333,
-    "total_elevation_gain": 76.5
-  },
-  {
-    "start_date": "2020-06-19T06:56:57Z",
-    "average_watts": 154.4,
-    "average_speed": 5.106,
-    "distance": 94220.3,
-    "moving_time": 18454,
-    "total_elevation_gain": 590.0
-  },
-  {
-    "start_date": "2020-06-20T18:13:47Z",
-    "average_watts": 136.1,
-    "average_speed": 5.711,
-    "distance": 5802.0,
-    "moving_time": 1016,
-    "total_elevation_gain": 71.1
-  },
-  {
-    "start_date": "2020-06-21T09:33:56Z",
-    "average_watts": 157.1,
-    "average_speed": 5.618,
-    "distance": 4325.7,
-    "moving_time": 770,
-    "total_elevation_gain": 34.8
-  },
-  {
-    "start_date": "2020-06-23T11:10:24Z",
-    "average_watts": 160.5,
-    "average_speed": 8.049,
-    "distance": 24379.6,
-    "moving_time": 3029,
-    "total_elevation_gain": 206.6
-  },
-  {
-    "start_date": "2020-06-24T19:20:54Z",
-    "average_watts": 149.2,
-    "average_speed": 7.026,
-    "distance": 15660.8,
-    "moving_time": 2229,
-    "total_elevation_gain": 109.3
-  },
-  {
-    "start_date": "2020-06-27T06:55:07Z",
-    "average_watts": 167.4,
-    "average_speed": 5.486,
-    "distance": 3834.9,
-    "moving_time": 699,
-    "total_elevation_gain": 39.4
-  },
-  {
-    "start_date": "2020-07-09T06:14:03Z",
-    "average_watts": 164.8,
-    "average_speed": 4.305,
-    "distance": 7715.1,
-    "moving_time": 1792,
-    "total_elevation_gain": 53.7
-  },
-  {
-    "start_date": "2020-07-12T19:16:17Z",
-    "average_watts": 136.0,
-    "average_speed": 9.924,
-    "distance": 24442.8,
-    "moving_time": 2463,
-    "total_elevation_gain": 224.2
-  },
-  {
-    "start_date": "2020-07-18T12:43:00Z",
-    "average_watts": 152.4,
-    "average_speed": 5.512,
-    "distance": 56706.1,
-    "moving_time": 10287,
-    "total_elevation_gain": 712.4
-  },
-  {
-    "start_date": "2020-07-20T10:42:54Z",
-    "average_watts": 138.6,
-    "average_speed": 5.792,
-    "distance": 38793.6,
-    "moving_time": 6698,
-    "total_elevation_gain": 256.1
-  },
-  {
-    "start_date": "2020-07-21T09:05:49Z",
-    "average_watts": 137.0,
-    "average_speed": 6.282,
-    "distance": 83944.7,
-    "moving_time": 13363,
-    "total_elevation_gain": 868.6
-  },
-  {
-    "start_date": "2020-07-24T18:21:14Z",
-    "average_watts": 155.5,
-    "average_speed": 5.253,
-    "distance": 7264.9,
-    "moving_time": 1383,
-    "total_elevation_gain": 106.7
-  },
-  {
-    "start_date": "2020-07-25T08:33:32Z",
-    "average_watts": 161.7,
-    "average_speed": 6.965,
-    "distance": 58663.4,
-    "moving_time": 8423,
-    "total_elevation_gain": 496.3
-  },
-  {
-    "start_date": "2020-07-27T17:40:12Z",
-    "average_watts": 140.8,
-    "average_speed": 5.466,
-    "distance": 91088.2,
-    "moving_time": 16663,
-    "total_elevation_gain": 867.9
-  },
-  {
-    "start_date": "2020-07-28T19:46:27Z",
-    "average_watts": 140.7,
-    "average_speed": 3.306,
-    "distance": 5507.0,
-    "moving_time": 1666,
-    "total_elevation_gain": 57.2
-  },
-  {
-    "start_date": "2020-07-31T18:26:29Z",
-    "average_watts": 167.1,
-    "average_speed": 3.864,
-    "distance": 5012.2,
-    "moving_time": 1297,
-    "total_elevation_gain": 41.3
-  },
-  {
-    "start_date": "2020-08-03T10:04:26Z",
-    "average_watts": 171.3,
-    "average_speed": 8.262,
-    "distance": 16490.9,
-    "moving_time": 1996,
-    "total_elevation_gain": 117.7
-  },
-  {
-    "start_date": "2020-08-04T13:13:37Z",
-    "average_watts": 135.9,
-    "average_speed": 8.839,
-    "distance": 14673.0,
-    "moving_time": 1660,
-    "total_elevation_gain": 163.8
-  },
-  {
-    "start_date": "2020-08-09T18:20:15Z",
-    "average_watts": 170.8,
-    "average_speed": 5.257,
-    "distance": 4052.8,
-    "moving_time": 771,
-    "total_elevation_gain": 23.8
-  },
-  {
-    "start_date": "2020-08-10T08:52:14Z",
-    "average_watts": 135.4,
-    "average_speed": 5.345,
-    "distance": 27932.1,
-    "moving_time": 5226,
-    "total_elevation_gain": 158.7
-  },
-  {
-    "start_date": "2020-08-12T13:31:07Z",
-    "average_watts": 146.7,
-    "average_speed": 5.759,
-    "distance": 35907.5,
-    "moving_time": 6235,
-    "total_elevation_gain": 201.4
-  },
-  {
-    "start_date": "2020-08-13T19:25:47Z",
-    "average_watts": 150.4,
-    "average_speed": 7.936,
-    "distance": 34626.8,
-    "moving_time": 4363,
-    "total_elevation_gain": 218.6
-  },
-  {
-    "start_date": "2020-08-15T13:43:36Z",
-    "average_watts": 141.0,
-    "average_speed": 5.789,
-    "distance": 7357.4,
-    "moving_time": 1271,
-    "total_elevation_gain": 98.1
-  },
-  {
-    "start_date": "2020-08-16T19:40:59Z",
-    "average_watts": 168.0,
-    "average_speed": 5.497,
-    "distance": 78084.0,
-    "moving_time": 14206,
-    "total_elevation_gain": 988.4
-  },
-  {
-    "start_date": "2020-08-17T16:37:14Z",
-    "average_watts": 135.5,
-    "average_speed": 5.427,
-    "distance": 3614.5,
-    "moving_time": 666,
-    "total_elevation_gain": 37.2
-  },
-  {
-    "start_date": "2020-08-18T13:18:51Z",
-    "average_watts": 160.1,
-    "average_speed": 7.06,
-    "distance": 29432.7,
-    "moving_time": 4169,
-    "total_elevation_gain": 202.6
-  },
-  {
-    "start_date": "2020-08-22T16:57:14Z",
-    "average_watts": 160.6,
-    "average_speed": 5.209,
-    "distance": 96069.9,
-    "moving_time": 18443,
-    "total_elevation_gain": 1002.5
-  },
-  {
-    "start_date": "2020-08-23T07:07:53Z",
-    "average_watts": 150.1,
-    "average_speed": 9.217,
-    "distance": 10313.4,
-    "moving_time": 1119,
-    "total_elevation_gain": 139.3
-  },
-  {
-    "start_date": "2020-08-24T13:48:08Z",
-    "average_watts": 145.7,
-    "average_speed": 6.431,
-    "distance": 59992.2,
-    "moving_time": 9329,
-    "total_elevation_gain": 786.4
-  },
-  {
-    "start_date": "2020-08-26T18:13:33Z",
-    "average_watts": 160.5,
-    "average_speed": 7.277,
-    "distance": 24900.3,
-    "moving_time": 3422,
-    "total_elevation_gain": 347.5
-  },
-  {
-    "start_date": "2020-08-27T14:09:27Z",
-    "average_watts": 135.6,
-    "average_speed": 7.92,
-    "distance": 23388.0,
-    "moving_time": 2953,
-    "total_elevation_gain": 311.0
-  },
-  {
-    "start_date": "2020-08-28T16:12:12Z",
-    "average_watts": 151.7,
-    "average_speed": 6.892,
-    "distance": 80613.5,
-    "moving_time": 11696,
-    "total_elevation_gain": 732.1
-  },
-  {
-    "start_date": "2020-09-01T13:05:17Z",
-    "average_watts": 164.3,
-    "average_speed": 4.839,
-    "distance": 5748.6,
-    "moving_time": 1188,
-    "total_elevation_gain": 55.4
-  },
-  {
-    "start_date": "2020-09-02T09:08:47Z",
-    "average_watts": 134.6,
-    "average_speed": 5.081,
-    "distance": 34655.7,
-    "moving_time": 6821,
-    "total_elevation_gain": 379.7
-  },
-  {
-    "start_date": "2020-09-04T18:35:55Z",
-    "average_watts": 144.1,
-    "average_speed": 4.7,
-    "distance": 6336.2,
-    "moving_time": 1348,
-    "total_elevation_gain": 52.3
-  },
-  {
-    "start_date": "2020-09-07T09:56:02Z",
-    "average_watts": 165.4,
-    "average_speed": 7.647,
-    "distance": 17793.5,
-    "moving_time": 2327,
-    "total_elevation_gain": 199.3
-  },
-  {
-    "start_date": "2020-09-09T17:48:48Z",
-    "average_watts": 153.5,
-    "average_speed": 5.566,
-    "distance": 5437.8,
-    "moving_time": 977,
-    "total_elevation_gain": 40.7
-  },
-  {
-    "start_date": "2020-09-10T16:57:50Z",
-    "average_watts": 165.8,
-    "average_speed": 9.923,
-    "distance": 16838.7,
-    "moving_time": 1697,
-    "total_elevation_gain": 214.9
-  },
-  {
-    "start_date": "2020-09-16T16:07:37Z",
-    "average_watts": 146.6,
-    "average_speed": 4.799,
-    "distance": 6680.1,
-    "moving_time": 1392,
-    "total_elevation_gain": 40.0
-  },
-  {
-    "start_date": "2020-09-17T09:23:36Z",
-    "average_watts": 138.9,
-    "average_speed": 7.838,
-    "distance": 21469.2,
-    "moving_time": 2739,
-    "total_elevation_gain": 165.9
-  },
-  {
-    "start_date": "2020-09-20T06:13:24Z",
-    "average_watts": 157.1,
-    "average_speed": 6.206,
-    "distance": 97623.1,
-    "moving_time": 15730,
-    "total_elevation_gain": 1014.2
-  },
-  {
-    "start_date": "2020-09-24T12:45:22Z",
-    "average_watts": 133.9,
-    "average_speed": 6.231,
-    "distance": 24439.4,
-    "moving_time": 3922,
-    "total_elevation_gain": 206.7
-  },
-  {
-    "start_date": "2020-09-25T18:59:12Z",
-    "average_watts": 171.2,
-    "average_speed": 4.456,
-    "distance": 6144.3,
-    "moving_time": 1379,
-    "total_elevation_gain": 66.0
-  },
-  {
-    "start_date": "2020-09-26T19:05:22Z",
-    "average_watts": 156.4,
-    "average_speed": 3.446,
-    "distance": 3814.6,
-    "moving_time": 1107,
-    "total_elevation_gain": 25.0
-  },
-  {
-    "start_date": "2020-09-27T13:39:50Z",
-    "average_watts": 136.4,
-    "average_speed": 7.439,
-    "distance": 13449.5,
-    "moving_time": 1808,
-    "total_elevation_gain": 171.2
-  },
-  {
-    "start_date": "2020-09-28T07:57:40Z",
-    "average_watts": 170.0,
-    "average_speed": 5.213,
-    "distance": 7563.9,
-    "moving_time": 1451,
-    "total_elevation_gain": 67.5
-  },
-  {
-    "start_date": "2020-09-30T11:42:00Z",
-    "average_watts": 145.5,
-    "average_speed": 9.352,
-    "distance": 21864.6,
-    "moving_time": 2338,
-    "total_elevation_gain": 290.2
-  },
-  {
-    "start_date": "2020-10-02T10:10:36Z",
-    "average_watts": 170.0,
-    "average_speed": 8.31,
-    "distance": 21199.1,
-    "moving_time": 2551,
-    "total_elevation_gain": 215.6
-  },
-  {
-    "start_date": "2020-10-05T17:11:08Z",
-    "average_watts": 143.1,
-    "average_speed": 7.731,
-    "distance": 30468.1,
-    "moving_time": 3941,
-    "total_elevation_gain": 327.2
-  },
-  {
-    "start_date": "2020-10-06T09:46:49Z",
-    "average_watts": 152.7,
-    "average_speed": 5.306,
-    "distance": 24008.1,
-    "moving_time": 4525,
-    "total_elevation_gain": 279.0
-  },
-  {
-    "start_date": "2020-10-07T19:38:19Z",
-    "average_watts": 136.1,
-    "average_speed": 6.548,
-    "distance": 90113.0,
-    "moving_time": 13761,
-    "total_elevation_gain": 600.7
-  },
-  {
-    "start_date": "2020-10-08T19:04:40Z",
-    "average_watts": 138.0,
-    "average_speed": 6.318,
-    "distance": 38128.5,
-    "moving_time": 6035,
-    "total_elevation_gain": 566.3
-  },
-  {
-    "start_date": "2020-10-09T13:39:33Z",
-    "average_watts": 156.0,
-    "average_speed": 5.018,
-    "distance": 96165.6,
-    "moving_time": 19165,
-    "total_elevation_gain": 921.8
-  },
-  {
-    "start_date": "2020-10-10T13:45:48Z",
-    "average_watts": 149.6,
-    "average_speed": 4.35,
-    "distance": 5254.3,
-    "moving_time": 1208,
-    "total_elevation_gain": 70.0
-  },
-  {
-    "start_date": "2020-10-13T10:24:15Z",
-    "average_watts": 146.1,
-    "average_speed": 5.96,
-    "distance": 89186.9,
-    "moving_time": 14963,
-    "total_elevation_gain": 782.2
-  },
-  {
-    "start_date": "2020-10-14T12:53:26Z",
-    "average_watts": 143.2,
-    "average_speed": 4.683,
-    "distance": 6658.5,
-    "moving_time": 1422,
-    "total_elevation_gain": 57.7
-  },
-  {
-    "start_date": "2020-10-16T16:43:13Z",
-    "average_watts": 136.9,
-    "average_speed": 8.819,
-    "distance": 21007.4,
-    "moving_time": 2382,
-    "total_elevation_gain": 192.6
-  },
-  {
-    "start_date": "2020-10-17T12:57:30Z",
-    "average_watts": 145.0,
-    "average_speed": 9.769,
-    "distance": 10960.9,
-    "moving_time": 1122,
-    "total_elevation_gain": 84.6
-  },
-  {
-    "start_date": "2020-10-20T16:31:47Z",
-    "average_watts": 136.9,
-    "average_speed": 3.874,
-    "distance": 5400.9,
-    "moving_time": 1394,
-    "total_elevation_gain": 47.6
-  },
-  {
-    "start_date": "2020-10-22T12:41:06Z",
-    "average_watts": 166.9,
-    "average_speed": 5.474,
-    "distance": 88682.6,
-    "moving_time": 16202,
-    "total_elevation_gain": 1230.7
-  },
-  {
-    "start_date": "2020-10-23T09:00:30Z",
-    "average_watts": 163.5,
-    "average_speed": 7.639,
-    "distance": 36911.9,
-    "moving_time": 4832,
-    "total_elevation_gain": 312.1
-  },
-  {
-    "start_date": "2020-10-24T17:01:23Z",
-    "average_watts": 156.8,
-    "average_speed": 8.884,
-    "distance": 23899.0,
-    "moving_time": 2690,
-    "total_elevation_gain": 242.0
-  },
-  {
-    "start_date": "2020-10-26T14:49:23Z",
-    "average_watts": 133.4,
-    "average_speed": 9.449,
-    "distance": 21316.5,
-    "moving_time": 2256,
-    "total_elevation_gain": 145.6
-  },
-  {
-    "start_date": "2020-10-28T06:20:20Z",
-    "average_watts": 163.0,
-    "average_speed": 9.493,
-    "distance": 17628.8,
-    "moving_time": 1857,
-    "total_elevation_gain": 244.3
-  },
-  {
-    "start_date": "2020-10-29T08:40:23Z",
-    "average_watts": 162.8,
-    "average_speed": 7.133,
-    "distance": 14408.3,
-    "moving_time": 2020,
-    "total_elevation_gain": 200.6
-  },
-  {
-    "start_date": "2020-10-31T19:58:43Z",
-    "average_watts": 150.1,
-    "average_speed": 5.318,
-    "distance": 4870.9,
-    "moving_time": 916,
-    "total_elevation_gain": 27.7
-  },
-  {
-    "start_date": "2020-11-01T19:41:21Z",
-    "average_watts": 155.6,
-    "average_speed": 7.698,
-    "distance": 39769.9,
-    "moving_time": 5166,
-    "total_elevation_gain": 423.9
-  },
-  {
-    "start_date": "2020-11-02T15:12:34Z",
-    "average_watts": 151.5,
-    "average_speed": 5.113,
-    "distance": 73182.8,
-    "moving_time": 14314,
-    "total_elevation_gain": 540.2
-  },
-  {
-    "start_date": "2020-11-04T16:44:44Z",
-    "average_watts": 140.0,
-    "average_speed": 8.731,
-    "distance": 24944.2,
-    "moving_time": 2857,
-    "total_elevation_gain": 347.8
-  },
-  {
-    "start_date": "2020-11-06T16:06:44Z",
-    "average_watts": 165.5,
-    "average_speed": 5.96,
-    "distance": 5435.9,
-    "moving_time": 912,
-    "total_elevation_gain": 63.4
-  },
-  {
-    "start_date": "2020-11-08T17:07:41Z",
-    "average_watts": 162.9,
-    "average_speed": 5.531,
-    "distance": 57990.0,
-    "moving_time": 10484,
-    "total_elevation_gain": 815.7
-  },
-  {
-    "start_date": "2020-11-09T10:31:43Z",
-    "average_watts": 166.0,
-    "average_speed": 4.544,
-    "distance": 3003.8,
-    "moving_time": 661,
-    "total_elevation_gain": 16.5
-  },
-  {
-    "start_date": "2020-11-10T09:14:39Z",
-    "average_watts": 138.7,
-    "average_speed": 3.522,
-    "distance": 6173.3,
-    "moving_time": 1753,
-    "total_elevation_gain": 49.1
-  },
-  {
-    "start_date": "2020-11-12T08:19:48Z",
-    "average_watts": 163.6,
-    "average_speed": 5.078,
-    "distance": 38352.1,
-    "moving_time": 7553,
-    "total_elevation_gain": 381.8
-  },
-  {
-    "start_date": "2020-11-15T17:14:32Z",
-    "average_watts": 152.9,
-    "average_speed": 5.251,
-    "distance": 23729.2,
-    "moving_time": 4519,
-    "total_elevation_gain": 166.1
-  },
-  {
-    "start_date": "2020-11-20T17:57:40Z",
-    "average_watts": 145.0,
-    "average_speed": 7.413,
-    "distance": 19853.2,
-    "moving_time": 2678,
-    "total_elevation_gain": 136.6
-  },
-  {
-    "start_date": "2020-11-21T10:54:55Z",
-    "average_watts": 168.0,
-    "average_speed": 5.605,
-    "distance": 61214.8,
-    "moving_time": 10922,
-    "total_elevation_gain": 616.7
-  },
-  {
-    "start_date": "2020-11-24T18:23:10Z",
-    "average_watts": 142.7,
-    "average_speed": 5.175,
-    "distance": 83576.7,
-    "moving_time": 16149,
-    "total_elevation_gain": 573.8
-  },
-  {
-    "start_date": "2020-11-25T06:02:57Z",
-    "average_watts": 165.0,
-    "average_speed": 8.708,
-    "distance": 17459.3,
-    "moving_time": 2005,
-    "total_elevation_gain": 231.0
-  },
-  {
-    "start_date": "2020-11-27T07:02:50Z",
-    "average_watts": 161.5,
-    "average_speed": 7.249,
-    "distance": 18832.5,
-    "moving_time": 2598,
-    "total_elevation_gain": 165.7
-  },
-  {
-    "start_date": "2020-11-28T18:37:30Z",
-    "average_watts": 162.1,
-    "average_speed": 9.557,
-    "distance": 14489.1,
-    "moving_time": 1516,
-    "total_elevation_gain": 169.0
-  },
-  {
-    "start_date": "2020-11-29T11:47:22Z",
-    "average_watts": 157.8,
-    "average_speed": 6.811,
-    "distance": 38116.6,
-    "moving_time": 5596,
-    "total_elevation_gain": 369.0
-  },
-  {
-    "start_date": "2020-12-01T15:25:12Z",
-    "average_watts": 156.5,
-    "average_speed": 6.995,
-    "distance": 84280.3,
-    "moving_time": 12049,
-    "total_elevation_gain": 845.9
-  },
-  {
-    "start_date": "2020-12-08T06:58:35Z",
-    "average_watts": 137.4,
-    "average_speed": 4.032,
-    "distance": 4278.2,
-    "moving_time": 1061,
-    "total_elevation_gain": 54.9
-  },
-  {
-    "start_date": "2020-12-11T10:49:54Z",
-    "average_watts": 144.2,
-    "average_speed": 4.748,
-    "distance": 3574.9,
-    "moving_time": 753,
-    "total_elevation_gain": 29.5
-  },
-  {
-    "start_date": "2020-12-13T14:54:44Z",
-    "average_watts": 163.6,
-    "average_speed": 5.178,
-    "distance": 73965.5,
-    "moving_time": 14285,
-    "total_elevation_gain": 815.9
-  },
-  {
-    "start_date": "2020-12-15T15:37:26Z",
-    "average_watts": 150.3,
-    "average_speed": 6.144,
-    "distance": 99000.8,
-    "moving_time": 16114,
-    "total_elevation_gain": 678.9
-  },
-  {
-    "start_date": "2020-12-18T06:09:56Z",
-    "average_watts": 152.8,
-    "average_speed": 6.225,
-    "distance": 69946.2,
-    "moving_time": 11237,
-    "total_elevation_gain": 955.0
-  },
-  {
-    "start_date": "2020-12-21T06:16:19Z",
-    "average_watts": 155.9,
-    "average_speed": 4.915,
-    "distance": 4698.8,
-    "moving_time": 956,
-    "total_elevation_gain": 68.5
-  },
-  {
-    "start_date": "2020-12-23T17:01:42Z",
-    "average_watts": 155.7,
-    "average_speed": 7.843,
-    "distance": 15239.2,
-    "moving_time": 1943,
-    "total_elevation_gain": 161.0
-  },
-  {
-    "start_date": "2020-12-27T09:57:57Z",
-    "average_watts": 156.6,
-    "average_speed": 8.177,
-    "distance": 14815.9,
-    "moving_time": 1812,
-    "total_elevation_gain": 191.4
-  },
-  {
-    "start_date": "2020-12-30T16:42:29Z",
-    "average_watts": 157.8,
-    "average_speed": 5.252,
-    "distance": 75532.2,
-    "moving_time": 14382,
-    "total_elevation_gain": 814.6
-  },
-  {
-    "start_date": "2020-12-31T18:03:57Z",
-    "average_watts": 161.4,
-    "average_speed": 7.746,
-    "distance": 22896.7,
-    "moving_time": 2956,
-    "total_elevation_gain": 196.7
-  },
-  {
-    "start_date": "2021-01-01T17:58:28Z",
-    "average_watts": 137.6,
-    "average_speed": 3.695,
-    "distance": 3107.7,
-    "moving_time": 841,
-    "total_elevation_gain": 26.6
-  },
-  {
-    "start_date": "2021-01-02T14:19:10Z",
-    "average_watts": 166.8,
-    "average_speed": 5.039,
-    "distance": 34267.2,
-    "moving_time": 6801,
-    "total_elevation_gain": 343.7
-  },
-  {
-    "start_date": "2021-01-05T09:16:03Z",
-    "average_watts": 161.9,
-    "average_speed": 3.656,
-    "distance": 3345.4,
-    "moving_time": 915,
-    "total_elevation_gain": 36.9
-  },
-  {
-    "start_date": "2021-01-08T09:06:55Z",
-    "average_watts": 165.2,
-    "average_speed": 3.493,
-    "distance": 5518.7,
-    "moving_time": 1580,
-    "total_elevation_gain": 42.2
-  },
-  {
-    "start_date": "2021-01-10T08:34:30Z",
-    "average_watts": 145.8,
-    "average_speed": 3.356,
-    "distance": 5443.1,
-    "moving_time": 1622,
-    "total_elevation_gain": 56.4
-  },
-  {
-    "start_date": "2021-01-12T15:47:43Z",
-    "average_watts": 137.9,
-    "average_speed": 7.019,
-    "distance": 19169.7,
-    "moving_time": 2731,
-    "total_elevation_gain": 173.7
-  },
-  {
-    "start_date": "2021-01-16T16:06:45Z",
-    "average_watts": 150.0,
-    "average_speed": 8.97,
-    "distance": 24937.2,
-    "moving_time": 2780,
-    "total_elevation_gain": 243.2
-  },
-  {
-    "start_date": "2021-01-18T14:33:42Z",
+    "start_date": "2020-05-04T17:20:39Z",
     "average_watts": 138.2,
-    "average_speed": 4.934,
-    "distance": 5847.1,
-    "moving_time": 1185,
-    "total_elevation_gain": 57.4
+    "average_speed": 3.126,
+    "distance": 3832.1,
+    "moving_time": 1226,
+    "total_elevation_gain": 46.5,
+    "type": "Ride"
   },
   {
-    "start_date": "2021-01-19T08:26:13Z",
-    "average_watts": 155.1,
-    "average_speed": 6.738,
-    "distance": 85612.1,
-    "moving_time": 12706,
-    "total_elevation_gain": 653.2
-  },
-  {
-    "start_date": "2021-01-21T14:30:51Z",
-    "average_watts": 142.4,
-    "average_speed": 6.504,
-    "distance": 94279.3,
-    "moving_time": 14495,
-    "total_elevation_gain": 1036.9
-  },
-  {
-    "start_date": "2021-01-22T18:00:30Z",
-    "average_watts": 164.3,
-    "average_speed": 6.225,
-    "distance": 84537.5,
-    "moving_time": 13581,
-    "total_elevation_gain": 1071.9
-  },
-  {
-    "start_date": "2021-01-23T06:32:32Z",
-    "average_watts": 149.8,
-    "average_speed": 7.096,
-    "distance": 15370.5,
-    "moving_time": 2166,
-    "total_elevation_gain": 205.4
-  },
-  {
-    "start_date": "2021-01-24T15:34:21Z",
-    "average_watts": 163.1,
-    "average_speed": 6.524,
-    "distance": 53626.3,
-    "moving_time": 8220,
-    "total_elevation_gain": 466.2
-  },
-  {
-    "start_date": "2021-01-25T16:11:26Z",
-    "average_watts": 154.3,
-    "average_speed": 4.969,
-    "distance": 3513.4,
-    "moving_time": 707,
-    "total_elevation_gain": 42.7
-  },
-  {
-    "start_date": "2021-01-27T09:48:27Z",
-    "average_watts": 136.1,
-    "average_speed": 5.948,
-    "distance": 65387.1,
-    "moving_time": 10994,
-    "total_elevation_gain": 820.1
-  },
-  {
-    "start_date": "2021-01-28T08:19:18Z",
-    "average_watts": 143.7,
-    "average_speed": 9.002,
-    "distance": 20362.6,
-    "moving_time": 2262,
-    "total_elevation_gain": 108.2
-  },
-  {
-    "start_date": "2021-01-30T12:53:23Z",
-    "average_watts": 171.4,
-    "average_speed": 5.178,
-    "distance": 90940.4,
-    "moving_time": 17562,
-    "total_elevation_gain": 801.5
-  },
-  {
-    "start_date": "2021-02-02T18:02:44Z",
-    "average_watts": 164.3,
-    "average_speed": 4.683,
-    "distance": 6083.7,
-    "moving_time": 1299,
-    "total_elevation_gain": 67.2
-  },
-  {
-    "start_date": "2021-02-03T06:15:54Z",
-    "average_watts": 157.0,
-    "average_speed": 7.96,
-    "distance": 12512.4,
-    "moving_time": 1572,
-    "total_elevation_gain": 134.5
-  },
-  {
-    "start_date": "2021-02-04T10:33:37Z",
-    "average_watts": 154.4,
-    "average_speed": 5.53,
-    "distance": 99877.5,
-    "moving_time": 18060,
-    "total_elevation_gain": 1272.8
-  },
-  {
-    "start_date": "2021-02-09T10:52:30Z",
-    "average_watts": 156.3,
-    "average_speed": 6.783,
-    "distance": 88226.1,
-    "moving_time": 13006,
-    "total_elevation_gain": 793.6
-  },
-  {
-    "start_date": "2021-02-11T10:23:31Z",
-    "average_watts": 157.3,
-    "average_speed": 6.114,
-    "distance": 30736.3,
-    "moving_time": 5027,
-    "total_elevation_gain": 432.7
-  },
-  {
-    "start_date": "2021-02-16T18:15:42Z",
-    "average_watts": 142.2,
-    "average_speed": 6.494,
-    "distance": 37412.4,
-    "moving_time": 5761,
-    "total_elevation_gain": 322.4
-  },
-  {
-    "start_date": "2021-02-18T11:25:53Z",
-    "average_watts": 170.5,
-    "average_speed": 5.513,
-    "distance": 85170.7,
-    "moving_time": 15449,
-    "total_elevation_gain": 892.3
-  },
-  {
-    "start_date": "2021-02-19T19:27:42Z",
-    "average_watts": 157.6,
-    "average_speed": 5.884,
-    "distance": 84739.0,
-    "moving_time": 14402,
-    "total_elevation_gain": 495.1
-  },
-  {
-    "start_date": "2021-02-20T19:57:57Z",
-    "average_watts": 141.8,
-    "average_speed": 7.418,
-    "distance": 12558.9,
-    "moving_time": 1693,
-    "total_elevation_gain": 188.1
-  },
-  {
-    "start_date": "2021-02-23T07:05:07Z",
-    "average_watts": 139.2,
-    "average_speed": 6.3,
-    "distance": 25176.0,
-    "moving_time": 3996,
-    "total_elevation_gain": 359.4
-  },
-  {
-    "start_date": "2021-02-24T10:36:01Z",
-    "average_watts": 143.8,
-    "average_speed": 6.668,
-    "distance": 61702.0,
-    "moving_time": 9253,
-    "total_elevation_gain": 599.5
-  },
-  {
-    "start_date": "2021-02-25T19:10:23Z",
-    "average_watts": 145.1,
-    "average_speed": 8.323,
-    "distance": 10928.3,
-    "moving_time": 1313,
-    "total_elevation_gain": 142.9
-  },
-  {
-    "start_date": "2021-02-26T19:51:46Z",
-    "average_watts": 161.6,
-    "average_speed": 9.917,
-    "distance": 12783.4,
-    "moving_time": 1289,
-    "total_elevation_gain": 101.7
-  },
-  {
-    "start_date": "2021-02-28T11:39:31Z",
-    "average_watts": 152.5,
-    "average_speed": 5.038,
-    "distance": 72306.4,
-    "moving_time": 14352,
-    "total_elevation_gain": 695.1
-  },
-  {
-    "start_date": "2021-03-01T07:17:48Z",
-    "average_watts": 136.0,
-    "average_speed": 6.757,
-    "distance": 71113.3,
-    "moving_time": 10524,
-    "total_elevation_gain": 642.0
-  },
-  {
-    "start_date": "2021-03-03T16:54:50Z",
-    "average_watts": 142.0,
-    "average_speed": 5.877,
-    "distance": 37169.1,
-    "moving_time": 6325,
-    "total_elevation_gain": 275.9
-  },
-  {
-    "start_date": "2021-03-04T09:26:15Z",
-    "average_watts": 158.2,
-    "average_speed": 8.205,
-    "distance": 17149.3,
-    "moving_time": 2090,
-    "total_elevation_gain": 183.6
-  },
-  {
-    "start_date": "2021-03-05T06:11:48Z",
-    "average_watts": 153.6,
-    "average_speed": 6.596,
-    "distance": 89378.9,
-    "moving_time": 13550,
-    "total_elevation_gain": 1040.4
-  },
-  {
-    "start_date": "2021-03-06T06:25:41Z",
-    "average_watts": 136.0,
-    "average_speed": 5.063,
-    "distance": 35615.5,
-    "moving_time": 7035,
-    "total_elevation_gain": 280.8
-  },
-  {
-    "start_date": "2021-03-07T14:53:56Z",
-    "average_watts": 157.5,
-    "average_speed": 5.29,
-    "distance": 76994.4,
-    "moving_time": 14554,
-    "total_elevation_gain": 483.1
-  },
-  {
-    "start_date": "2021-03-09T07:09:36Z",
-    "average_watts": 148.8,
-    "average_speed": 7.829,
-    "distance": 33882.2,
-    "moving_time": 4328,
-    "total_elevation_gain": 228.3
-  },
-  {
-    "start_date": "2021-03-13T09:41:14Z",
-    "average_watts": 160.6,
-    "average_speed": 4.3,
-    "distance": 6385.0,
-    "moving_time": 1485,
-    "total_elevation_gain": 63.0
-  },
-  {
-    "start_date": "2021-03-14T08:17:42Z",
-    "average_watts": 141.0,
-    "average_speed": 4.29,
-    "distance": 3239.3,
-    "moving_time": 755,
-    "total_elevation_gain": 26.0
-  },
-  {
-    "start_date": "2021-03-15T15:15:38Z",
-    "average_watts": 150.8,
-    "average_speed": 5.525,
-    "distance": 6458.5,
-    "moving_time": 1169,
-    "total_elevation_gain": 90.2
-  },
-  {
-    "start_date": "2021-03-16T07:42:55Z",
-    "average_watts": 155.0,
-    "average_speed": 6.006,
-    "distance": 87492.4,
-    "moving_time": 14568,
-    "total_elevation_gain": 1257.8
-  },
-  {
-    "start_date": "2021-03-18T14:59:01Z",
-    "average_watts": 146.9,
-    "average_speed": 6.65,
-    "distance": 75295.5,
-    "moving_time": 11322,
-    "total_elevation_gain": 540.7
-  },
-  {
-    "start_date": "2021-03-21T16:46:25Z",
-    "average_watts": 134.9,
-    "average_speed": 5.059,
-    "distance": 64039.7,
-    "moving_time": 12658,
-    "total_elevation_gain": 405.6
-  },
-  {
-    "start_date": "2021-03-22T14:28:58Z",
-    "average_watts": 160.5,
-    "average_speed": 6.682,
-    "distance": 77163.6,
-    "moving_time": 11548,
-    "total_elevation_gain": 497.7
-  },
-  {
-    "start_date": "2021-03-23T18:55:47Z",
-    "average_watts": 154.8,
-    "average_speed": 6.315,
-    "distance": 21086.6,
-    "moving_time": 3339,
-    "total_elevation_gain": 218.7
-  },
-  {
-    "start_date": "2021-03-25T16:03:15Z",
-    "average_watts": 145.0,
-    "average_speed": 5.473,
-    "distance": 32432.0,
-    "moving_time": 5926,
-    "total_elevation_gain": 305.0
-  },
-  {
-    "start_date": "2021-03-26T14:34:12Z",
-    "average_watts": 153.2,
-    "average_speed": 8.06,
-    "distance": 17660.0,
-    "moving_time": 2191,
-    "total_elevation_gain": 234.4
-  },
-  {
-    "start_date": "2021-03-27T15:47:21Z",
-    "average_watts": 140.9,
-    "average_speed": 9.87,
-    "distance": 16324.2,
-    "moving_time": 1654,
-    "total_elevation_gain": 90.8
-  },
-  {
-    "start_date": "2021-03-28T06:30:41Z",
-    "average_watts": 167.0,
-    "average_speed": 7.019,
-    "distance": 17681.3,
-    "moving_time": 2519,
-    "total_elevation_gain": 249.5
-  },
-  {
-    "start_date": "2021-03-29T10:58:26Z",
-    "average_watts": 140.5,
-    "average_speed": 8.871,
-    "distance": 18265.3,
-    "moving_time": 2059,
-    "total_elevation_gain": 175.7
-  },
-  {
-    "start_date": "2021-03-30T17:24:21Z",
-    "average_watts": 152.9,
-    "average_speed": 5.336,
-    "distance": 4221.1,
-    "moving_time": 791,
-    "total_elevation_gain": 33.0
-  },
-  {
-    "start_date": "2021-04-02T06:36:02Z",
-    "average_watts": 173.3,
-    "average_speed": 5.547,
-    "distance": 80730.2,
-    "moving_time": 14553,
-    "total_elevation_gain": 1040.9
-  },
-  {
-    "start_date": "2021-04-03T19:14:16Z",
-    "average_watts": 157.9,
-    "average_speed": 4.964,
-    "distance": 5738.0,
-    "moving_time": 1156,
-    "total_elevation_gain": 55.6
-  },
-  {
-    "start_date": "2021-04-04T08:12:26Z",
-    "average_watts": 169.6,
-    "average_speed": 3.337,
-    "distance": 4625.7,
-    "moving_time": 1386,
-    "total_elevation_gain": 67.2
-  },
-  {
-    "start_date": "2021-04-08T17:25:14Z",
-    "average_watts": 171.5,
-    "average_speed": 6.814,
-    "distance": 77030.8,
-    "moving_time": 11305,
-    "total_elevation_gain": 865.3
-  },
-  {
-    "start_date": "2021-04-09T10:56:19Z",
-    "average_watts": 139.0,
-    "average_speed": 7.306,
-    "distance": 16197.7,
-    "moving_time": 2217,
-    "total_elevation_gain": 176.7
-  },
-  {
-    "start_date": "2021-04-10T07:00:22Z",
-    "average_watts": 138.0,
-    "average_speed": 9.8,
-    "distance": 18709.1,
-    "moving_time": 1909,
-    "total_elevation_gain": 123.5
-  },
-  {
-    "start_date": "2021-04-11T18:57:38Z",
-    "average_watts": 165.5,
-    "average_speed": 7.847,
-    "distance": 21703.7,
-    "moving_time": 2766,
-    "total_elevation_gain": 247.3
-  },
-  {
-    "start_date": "2021-04-12T07:52:37Z",
-    "average_watts": 174.3,
-    "average_speed": 6.903,
-    "distance": 37543.8,
-    "moving_time": 5439,
-    "total_elevation_gain": 307.3
-  },
-  {
-    "start_date": "2021-04-14T18:39:17Z",
-    "average_watts": 174.5,
-    "average_speed": 5.303,
-    "distance": 4661.7,
-    "moving_time": 879,
-    "total_elevation_gain": 47.9
-  },
-  {
-    "start_date": "2021-04-15T11:09:44Z",
-    "average_watts": 167.5,
-    "average_speed": 6.722,
-    "distance": 67443.8,
-    "moving_time": 10034,
-    "total_elevation_gain": 604.2
-  },
-  {
-    "start_date": "2021-04-18T15:00:16Z",
-    "average_watts": 150.4,
-    "average_speed": 7.518,
-    "distance": 30688.1,
-    "moving_time": 4082,
-    "total_elevation_gain": 326.6
-  },
-  {
-    "start_date": "2021-04-22T06:29:18Z",
-    "average_watts": 137.9,
-    "average_speed": 5.587,
-    "distance": 85147.5,
-    "moving_time": 15241,
-    "total_elevation_gain": 985.3
-  },
-  {
-    "start_date": "2021-04-23T13:46:46Z",
-    "average_watts": 137.8,
-    "average_speed": 3.934,
-    "distance": 4811.2,
-    "moving_time": 1223,
-    "total_elevation_gain": 33.6
-  },
-  {
-    "start_date": "2021-04-25T14:20:35Z",
-    "average_watts": 140.9,
-    "average_speed": 8.535,
-    "distance": 24922.2,
-    "moving_time": 2920,
-    "total_elevation_gain": 357.0
-  },
-  {
-    "start_date": "2021-04-26T17:43:49Z",
-    "average_watts": 159.8,
-    "average_speed": 7.842,
-    "distance": 31375.0,
-    "moving_time": 4001,
-    "total_elevation_gain": 246.0
-  },
-  {
-    "start_date": "2021-04-28T17:08:13Z",
-    "average_watts": 137.0,
-    "average_speed": 4.376,
-    "distance": 5746.0,
-    "moving_time": 1313,
-    "total_elevation_gain": 68.3
-  },
-  {
-    "start_date": "2021-04-30T12:57:59Z",
-    "average_watts": 147.4,
-    "average_speed": 4.631,
-    "distance": 6164.2,
-    "moving_time": 1331,
-    "total_elevation_gain": 74.8
-  },
-  {
-    "start_date": "2021-05-03T15:46:20Z",
-    "average_watts": 143.1,
-    "average_speed": 8.502,
-    "distance": 21756.4,
-    "moving_time": 2559,
-    "total_elevation_gain": 294.1
-  },
-  {
-    "start_date": "2021-05-04T10:57:22Z",
-    "average_watts": 171.3,
-    "average_speed": 5.293,
-    "distance": 91026.1,
-    "moving_time": 17196,
-    "total_elevation_gain": 1015.6
-  },
-  {
-    "start_date": "2021-05-05T08:57:17Z",
-    "average_watts": 150.3,
-    "average_speed": 7.143,
-    "distance": 23287.0,
-    "moving_time": 3260,
-    "total_elevation_gain": 296.1
-  },
-  {
-    "start_date": "2021-05-08T08:05:18Z",
-    "average_watts": 163.6,
-    "average_speed": 8.57,
-    "distance": 16917.0,
-    "moving_time": 1974,
-    "total_elevation_gain": 245.2
-  },
-  {
-    "start_date": "2021-05-10T07:17:36Z",
-    "average_watts": 159.4,
-    "average_speed": 8.479,
-    "distance": 22055.0,
-    "moving_time": 2601,
-    "total_elevation_gain": 299.6
-  },
-  {
-    "start_date": "2021-05-11T12:03:24Z",
-    "average_watts": 140.7,
-    "average_speed": 8.515,
-    "distance": 20835.8,
-    "moving_time": 2447,
-    "total_elevation_gain": 239.2
-  },
-  {
-    "start_date": "2021-05-13T07:21:05Z",
-    "average_watts": 152.2,
-    "average_speed": 7.994,
-    "distance": 20640.4,
-    "moving_time": 2582,
-    "total_elevation_gain": 260.7
-  },
-  {
-    "start_date": "2021-05-14T06:16:23Z",
-    "average_watts": 137.8,
-    "average_speed": 7.519,
-    "distance": 25308.3,
-    "moving_time": 3366,
-    "total_elevation_gain": 373.8
-  },
-  {
-    "start_date": "2021-05-15T12:19:37Z",
-    "average_watts": 160.1,
-    "average_speed": 3.538,
-    "distance": 3389.0,
-    "moving_time": 958,
-    "total_elevation_gain": 36.3
-  },
-  {
-    "start_date": "2021-05-16T10:59:37Z",
-    "average_watts": 174.5,
-    "average_speed": 4.845,
-    "distance": 6225.9,
-    "moving_time": 1285,
-    "total_elevation_gain": 86.4
-  },
-  {
-    "start_date": "2021-05-17T15:53:43Z",
-    "average_watts": 139.6,
-    "average_speed": 5.996,
-    "distance": 90909.1,
-    "moving_time": 15161,
-    "total_elevation_gain": 799.9
-  },
-  {
-    "start_date": "2021-05-20T10:48:23Z",
-    "average_watts": 164.1,
-    "average_speed": 7.177,
-    "distance": 22385.8,
-    "moving_time": 3119,
-    "total_elevation_gain": 258.4
-  },
-  {
-    "start_date": "2021-05-21T14:30:58Z",
-    "average_watts": 146.2,
-    "average_speed": 5.545,
-    "distance": 4302.7,
-    "moving_time": 776,
-    "total_elevation_gain": 35.1
-  },
-  {
-    "start_date": "2021-05-22T11:48:49Z",
-    "average_watts": 170.3,
-    "average_speed": 6.147,
-    "distance": 64795.4,
-    "moving_time": 10541,
-    "total_elevation_gain": 873.3
-  },
-  {
-    "start_date": "2021-05-23T09:02:34Z",
-    "average_watts": 137.4,
-    "average_speed": 5.018,
-    "distance": 83841.0,
-    "moving_time": 16708,
-    "total_elevation_gain": 1093.2
-  },
-  {
-    "start_date": "2021-05-25T14:00:28Z",
-    "average_watts": 166.3,
-    "average_speed": 5.266,
-    "distance": 80452.4,
-    "moving_time": 15278,
-    "total_elevation_gain": 1170.8
-  },
-  {
-    "start_date": "2021-05-26T06:18:21Z",
-    "average_watts": 162.6,
-    "average_speed": 6.417,
-    "distance": 33874.5,
-    "moving_time": 5279,
-    "total_elevation_gain": 206.4
-  },
-  {
-    "start_date": "2021-05-30T13:56:47Z",
-    "average_watts": 163.3,
-    "average_speed": 5.469,
-    "distance": 4955.2,
-    "moving_time": 906,
-    "total_elevation_gain": 56.1
-  },
-  {
-    "start_date": "2021-05-31T09:14:38Z",
-    "average_watts": 135.9,
-    "average_speed": 5.603,
-    "distance": 3367.6,
-    "moving_time": 601,
-    "total_elevation_gain": 21.6
-  },
-  {
-    "start_date": "2021-06-01T13:10:31Z",
-    "average_watts": 142.9,
-    "average_speed": 9.607,
-    "distance": 12661.7,
-    "moving_time": 1318,
-    "total_elevation_gain": 135.1
-  },
-  {
-    "start_date": "2021-06-03T14:28:18Z",
+    "start_date": "2020-05-05T07:48:31Z",
     "average_watts": 163.7,
-    "average_speed": 5.198,
-    "distance": 3103.0,
-    "moving_time": 597,
-    "total_elevation_gain": 39.1
-  },
-  {
-    "start_date": "2021-06-04T17:59:28Z",
-    "average_watts": 163.0,
-    "average_speed": 9.482,
-    "distance": 15560.6,
-    "moving_time": 1641,
-    "total_elevation_gain": 88.7
-  },
-  {
-    "start_date": "2021-06-05T12:08:43Z",
-    "average_watts": 155.6,
-    "average_speed": 5.682,
-    "distance": 53311.7,
-    "moving_time": 9383,
-    "total_elevation_gain": 764.6
-  },
-  {
-    "start_date": "2021-06-07T12:49:18Z",
-    "average_watts": 142.7,
-    "average_speed": 7.904,
-    "distance": 14258.8,
-    "moving_time": 1804,
-    "total_elevation_gain": 92.6
-  },
-  {
-    "start_date": "2021-06-11T09:38:24Z",
-    "average_watts": 157.2,
-    "average_speed": 8.888,
-    "distance": 22370.9,
-    "moving_time": 2517,
-    "total_elevation_gain": 192.4
-  },
-  {
-    "start_date": "2021-06-13T12:09:16Z",
-    "average_watts": 158.4,
-    "average_speed": 6.285,
-    "distance": 75277.5,
-    "moving_time": 11978,
-    "total_elevation_gain": 538.5
-  },
-  {
-    "start_date": "2021-06-16T17:50:19Z",
-    "average_watts": 174.7,
-    "average_speed": 5.952,
-    "distance": 34667.7,
-    "moving_time": 5825,
-    "total_elevation_gain": 265.1
-  },
-  {
-    "start_date": "2021-06-17T11:09:53Z",
-    "average_watts": 139.8,
-    "average_speed": 5.672,
-    "distance": 38714.4,
-    "moving_time": 6826,
-    "total_elevation_gain": 250.1
-  },
-  {
-    "start_date": "2021-06-18T19:40:08Z",
-    "average_watts": 146.7,
-    "average_speed": 6.608,
-    "distance": 50614.2,
-    "moving_time": 7660,
-    "total_elevation_gain": 285.3
-  },
-  {
-    "start_date": "2021-06-20T12:07:15Z",
-    "average_watts": 160.5,
-    "average_speed": 5.474,
-    "distance": 6021.6,
-    "moving_time": 1100,
-    "total_elevation_gain": 53.6
-  },
-  {
-    "start_date": "2021-06-21T07:22:24Z",
-    "average_watts": 166.0,
-    "average_speed": 6.686,
-    "distance": 97294.4,
-    "moving_time": 14551,
-    "total_elevation_gain": 941.6
-  },
-  {
-    "start_date": "2021-06-23T14:46:22Z",
-    "average_watts": 163.2,
-    "average_speed": 6.957,
-    "distance": 36168.9,
-    "moving_time": 5199,
-    "total_elevation_gain": 465.9
-  },
-  {
-    "start_date": "2021-06-24T07:52:09Z",
-    "average_watts": 154.9,
-    "average_speed": 6.134,
-    "distance": 94222.6,
-    "moving_time": 15360,
-    "total_elevation_gain": 1043.4
-  },
-  {
-    "start_date": "2021-06-25T14:09:28Z",
-    "average_watts": 145.7,
-    "average_speed": 6.289,
-    "distance": 88629.1,
-    "moving_time": 14092,
-    "total_elevation_gain": 1169.4
-  },
-  {
-    "start_date": "2021-06-27T08:22:08Z",
-    "average_watts": 155.7,
-    "average_speed": 6.946,
-    "distance": 85476.6,
-    "moving_time": 12305,
-    "total_elevation_gain": 761.3
-  },
-  {
-    "start_date": "2021-06-28T15:20:41Z",
-    "average_watts": 142.6,
-    "average_speed": 4.788,
-    "distance": 4701.6,
-    "moving_time": 982,
-    "total_elevation_gain": 60.8
-  },
-  {
-    "start_date": "2021-06-29T09:53:57Z",
-    "average_watts": 152.4,
-    "average_speed": 7.722,
-    "distance": 17497.9,
-    "moving_time": 2266,
-    "total_elevation_gain": 96.6
-  },
-  {
-    "start_date": "2021-06-30T14:42:54Z",
-    "average_watts": 143.0,
-    "average_speed": 8.421,
-    "distance": 17187.3,
-    "moving_time": 2041,
-    "total_elevation_gain": 95.0
-  },
-  {
-    "start_date": "2021-07-02T15:34:41Z",
-    "average_watts": 169.5,
-    "average_speed": 3.789,
-    "distance": 5479.1,
-    "moving_time": 1446,
-    "total_elevation_gain": 58.8
-  },
-  {
-    "start_date": "2021-07-05T10:22:36Z",
-    "average_watts": 169.8,
-    "average_speed": 6.068,
-    "distance": 77670.3,
-    "moving_time": 12800,
-    "total_elevation_gain": 390.4
-  },
-  {
-    "start_date": "2021-07-08T08:10:46Z",
-    "average_watts": 175.4,
-    "average_speed": 9.006,
-    "distance": 21335.8,
-    "moving_time": 2369,
-    "total_elevation_gain": 111.7
-  },
-  {
-    "start_date": "2021-07-09T15:48:46Z",
-    "average_watts": 159.1,
-    "average_speed": 5.293,
-    "distance": 3048.5,
-    "moving_time": 576,
-    "total_elevation_gain": 26.9
-  },
-  {
-    "start_date": "2021-07-12T07:20:52Z",
-    "average_watts": 154.5,
-    "average_speed": 4.335,
-    "distance": 7408.4,
-    "moving_time": 1709,
-    "total_elevation_gain": 52.8
-  },
-  {
-    "start_date": "2021-07-15T09:14:05Z",
-    "average_watts": 149.7,
-    "average_speed": 9.062,
-    "distance": 21584.8,
-    "moving_time": 2382,
-    "total_elevation_gain": 212.4
-  },
-  {
-    "start_date": "2021-07-19T10:24:45Z",
-    "average_watts": 159.4,
-    "average_speed": 7.595,
-    "distance": 16754.5,
-    "moving_time": 2206,
-    "total_elevation_gain": 91.9
-  },
-  {
-    "start_date": "2021-07-21T12:34:48Z",
-    "average_watts": 170.4,
-    "average_speed": 8.84,
-    "distance": 11651.2,
-    "moving_time": 1318,
-    "total_elevation_gain": 174.5
-  },
-  {
-    "start_date": "2021-07-26T07:28:22Z",
-    "average_watts": 148.3,
-    "average_speed": 6.112,
-    "distance": 33321.4,
-    "moving_time": 5452,
-    "total_elevation_gain": 310.3
-  },
-  {
-    "start_date": "2021-07-29T15:59:58Z",
-    "average_watts": 172.9,
-    "average_speed": 8.515,
-    "distance": 14671.1,
-    "moving_time": 1723,
-    "total_elevation_gain": 185.9
-  },
-  {
-    "start_date": "2021-08-01T17:30:26Z",
-    "average_watts": 142.9,
-    "average_speed": 7.378,
-    "distance": 37879.0,
-    "moving_time": 5134,
-    "total_elevation_gain": 341.6
-  },
-  {
-    "start_date": "2021-08-03T11:09:01Z",
-    "average_watts": 163.6,
-    "average_speed": 7.073,
-    "distance": 20291.9,
-    "moving_time": 2869,
-    "total_elevation_gain": 150.1
-  },
-  {
-    "start_date": "2021-08-04T06:47:51Z",
-    "average_watts": 149.3,
-    "average_speed": 6.957,
-    "distance": 96452.1,
-    "moving_time": 13864,
-    "total_elevation_gain": 955.0
-  },
-  {
-    "start_date": "2021-08-05T07:29:57Z",
-    "average_watts": 151.9,
-    "average_speed": 4.414,
-    "distance": 5937.3,
-    "moving_time": 1345,
-    "total_elevation_gain": 66.9
-  },
-  {
-    "start_date": "2021-08-07T14:41:19Z",
-    "average_watts": 163.1,
-    "average_speed": 5.692,
-    "distance": 80021.0,
-    "moving_time": 14059,
-    "total_elevation_gain": 1139.6
-  },
-  {
-    "start_date": "2021-08-10T08:13:18Z",
-    "average_watts": 142.0,
-    "average_speed": 5.283,
-    "distance": 27734.3,
-    "moving_time": 5250,
-    "total_elevation_gain": 290.7
-  },
-  {
-    "start_date": "2021-08-12T17:09:08Z",
-    "average_watts": 155.1,
-    "average_speed": 5.5,
-    "distance": 51489.3,
-    "moving_time": 9361,
-    "total_elevation_gain": 665.3
-  },
-  {
-    "start_date": "2021-08-13T13:18:19Z",
-    "average_watts": 152.1,
-    "average_speed": 6.852,
-    "distance": 20322.6,
-    "moving_time": 2966,
-    "total_elevation_gain": 214.6
-  },
-  {
-    "start_date": "2021-08-16T14:55:13Z",
-    "average_watts": 157.2,
-    "average_speed": 4.18,
-    "distance": 3377.1,
-    "moving_time": 808,
-    "total_elevation_gain": 32.2
-  },
-  {
-    "start_date": "2021-08-18T08:28:40Z",
-    "average_watts": 141.9,
-    "average_speed": 7.823,
-    "distance": 24664.6,
-    "moving_time": 3153,
-    "total_elevation_gain": 336.8
-  },
-  {
-    "start_date": "2021-08-19T06:14:36Z",
-    "average_watts": 160.5,
-    "average_speed": 3.959,
-    "distance": 3238.7,
-    "moving_time": 818,
-    "total_elevation_gain": 40.7
-  },
-  {
-    "start_date": "2021-08-23T17:33:17Z",
-    "average_watts": 144.6,
-    "average_speed": 5.097,
-    "distance": 6921.3,
-    "moving_time": 1358,
-    "total_elevation_gain": 38.5
-  },
-  {
-    "start_date": "2021-08-26T10:29:30Z",
-    "average_watts": 147.2,
-    "average_speed": 8.04,
-    "distance": 23572.9,
-    "moving_time": 2932,
-    "total_elevation_gain": 342.7
-  },
-  {
-    "start_date": "2021-08-28T10:27:18Z",
-    "average_watts": 139.9,
-    "average_speed": 5.912,
-    "distance": 28828.7,
-    "moving_time": 4876,
-    "total_elevation_gain": 303.1
-  },
-  {
-    "start_date": "2021-08-29T09:36:09Z",
-    "average_watts": 170.9,
-    "average_speed": 5.313,
-    "distance": 63969.1,
-    "moving_time": 12041,
-    "total_elevation_gain": 716.6
-  },
-  {
-    "start_date": "2021-08-31T14:34:14Z",
-    "average_watts": 171.6,
-    "average_speed": 9.019,
-    "distance": 22086.6,
-    "moving_time": 2449,
-    "total_elevation_gain": 208.3
-  },
-  {
-    "start_date": "2021-09-02T13:21:26Z",
-    "average_watts": 148.1,
-    "average_speed": 7.604,
-    "distance": 10676.5,
-    "moving_time": 1404,
-    "total_elevation_gain": 88.2
-  },
-  {
-    "start_date": "2021-09-06T17:19:45Z",
-    "average_watts": 167.6,
-    "average_speed": 7.35,
-    "distance": 11605.3,
-    "moving_time": 1579,
-    "total_elevation_gain": 78.6
-  },
-  {
-    "start_date": "2021-09-07T12:50:01Z",
-    "average_watts": 171.2,
-    "average_speed": 8.937,
-    "distance": 22995.2,
-    "moving_time": 2573,
-    "total_elevation_gain": 240.9
-  },
-  {
-    "start_date": "2021-09-09T11:42:53Z",
-    "average_watts": 167.5,
-    "average_speed": 6.694,
-    "distance": 77470.5,
-    "moving_time": 11573,
-    "total_elevation_gain": 1059.4
-  },
-  {
-    "start_date": "2021-09-12T06:06:40Z",
-    "average_watts": 164.7,
-    "average_speed": 7.763,
-    "distance": 20285.5,
-    "moving_time": 2613,
-    "total_elevation_gain": 304.0
-  },
-  {
-    "start_date": "2021-09-14T18:36:18Z",
-    "average_watts": 170.7,
-    "average_speed": 6.63,
-    "distance": 56641.9,
-    "moving_time": 8543,
-    "total_elevation_gain": 739.6
-  },
-  {
-    "start_date": "2021-09-15T09:30:50Z",
-    "average_watts": 142.3,
-    "average_speed": 8.53,
-    "distance": 19338.6,
-    "moving_time": 2267,
-    "total_elevation_gain": 138.7
-  },
-  {
-    "start_date": "2021-09-16T19:35:06Z",
-    "average_watts": 169.6,
-    "average_speed": 9.191,
-    "distance": 23456.1,
-    "moving_time": 2552,
-    "total_elevation_gain": 250.3
-  },
-  {
-    "start_date": "2021-09-18T16:48:48Z",
-    "average_watts": 142.4,
-    "average_speed": 5.707,
-    "distance": 32308.8,
-    "moving_time": 5661,
-    "total_elevation_gain": 370.2
-  },
-  {
-    "start_date": "2021-09-19T08:08:39Z",
-    "average_watts": 154.4,
-    "average_speed": 5.3,
-    "distance": 51953.1,
-    "moving_time": 9803,
-    "total_elevation_gain": 624.8
-  },
-  {
-    "start_date": "2021-09-21T19:18:27Z",
-    "average_watts": 175.3,
-    "average_speed": 6.164,
-    "distance": 90191.0,
-    "moving_time": 14633,
-    "total_elevation_gain": 1159.5
-  },
-  {
-    "start_date": "2021-09-22T14:03:43Z",
-    "average_watts": 150.0,
-    "average_speed": 6.616,
-    "distance": 79468.9,
-    "moving_time": 12011,
-    "total_elevation_gain": 561.5
-  },
-  {
-    "start_date": "2021-09-28T14:29:45Z",
-    "average_watts": 168.8,
-    "average_speed": 5.015,
-    "distance": 96841.8,
-    "moving_time": 19309,
-    "total_elevation_gain": 1039.8
-  },
-  {
-    "start_date": "2021-09-30T13:05:09Z",
-    "average_watts": 138.8,
-    "average_speed": 7.243,
-    "distance": 24786.3,
-    "moving_time": 3422,
-    "total_elevation_gain": 172.6
-  },
-  {
-    "start_date": "2021-10-03T11:51:20Z",
-    "average_watts": 168.8,
-    "average_speed": 6.686,
-    "distance": 35716.5,
-    "moving_time": 5342,
-    "total_elevation_gain": 459.6
-  },
-  {
-    "start_date": "2021-10-04T10:22:47Z",
-    "average_watts": 163.3,
-    "average_speed": 9.77,
-    "distance": 21298.3,
-    "moving_time": 2180,
-    "total_elevation_gain": 112.1
-  },
-  {
-    "start_date": "2021-10-05T06:30:10Z",
-    "average_watts": 157.9,
-    "average_speed": 3.793,
-    "distance": 4024.8,
-    "moving_time": 1061,
-    "total_elevation_gain": 50.0
-  },
-  {
-    "start_date": "2021-10-07T17:03:59Z",
-    "average_watts": 175.1,
-    "average_speed": 5.612,
-    "distance": 25577.2,
-    "moving_time": 4558,
-    "total_elevation_gain": 181.1
-  },
-  {
-    "start_date": "2021-10-08T07:41:28Z",
-    "average_watts": 149.3,
-    "average_speed": 5.444,
-    "distance": 5661.9,
-    "moving_time": 1040,
-    "total_elevation_gain": 53.4
-  },
-  {
-    "start_date": "2021-10-12T16:17:06Z",
-    "average_watts": 175.0,
-    "average_speed": 5.543,
-    "distance": 34355.6,
-    "moving_time": 6198,
-    "total_elevation_gain": 392.0
-  },
-  {
-    "start_date": "2021-10-15T15:48:01Z",
-    "average_watts": 148.2,
-    "average_speed": 4.431,
-    "distance": 6509.2,
-    "moving_time": 1469,
-    "total_elevation_gain": 83.3
-  },
-  {
-    "start_date": "2021-10-16T13:31:46Z",
-    "average_watts": 168.9,
-    "average_speed": 6.085,
-    "distance": 82508.4,
-    "moving_time": 13559,
-    "total_elevation_gain": 732.6
-  },
-  {
-    "start_date": "2021-10-18T11:12:22Z",
-    "average_watts": 159.0,
-    "average_speed": 6.412,
-    "distance": 39906.3,
-    "moving_time": 6224,
-    "total_elevation_gain": 384.6
-  },
-  {
-    "start_date": "2021-10-19T18:14:22Z",
-    "average_watts": 152.4,
-    "average_speed": 3.951,
-    "distance": 6839.5,
-    "moving_time": 1731,
-    "total_elevation_gain": 99.1
-  },
-  {
-    "start_date": "2021-10-24T13:14:39Z",
-    "average_watts": 145.8,
-    "average_speed": 6.386,
-    "distance": 35069.3,
-    "moving_time": 5492,
-    "total_elevation_gain": 309.0
-  },
-  {
-    "start_date": "2021-10-25T10:34:54Z",
-    "average_watts": 141.6,
-    "average_speed": 4.062,
-    "distance": 7997.8,
-    "moving_time": 1969,
-    "total_elevation_gain": 82.3
-  },
-  {
-    "start_date": "2021-10-26T10:44:03Z",
-    "average_watts": 149.1,
-    "average_speed": 6.489,
-    "distance": 32093.9,
-    "moving_time": 4946,
-    "total_elevation_gain": 395.3
-  },
-  {
-    "start_date": "2021-10-30T13:33:56Z",
-    "average_watts": 152.0,
-    "average_speed": 4.187,
-    "distance": 7021.3,
-    "moving_time": 1677,
-    "total_elevation_gain": 69.1
-  },
-  {
-    "start_date": "2021-10-31T12:50:05Z",
-    "average_watts": 138.5,
-    "average_speed": 7.691,
-    "distance": 15435.2,
-    "moving_time": 2007,
-    "total_elevation_gain": 227.1
-  },
-  {
-    "start_date": "2021-11-01T12:31:45Z",
-    "average_watts": 141.3,
-    "average_speed": 5.862,
-    "distance": 26945.3,
-    "moving_time": 4597,
-    "total_elevation_gain": 202.9
-  },
-  {
-    "start_date": "2021-11-06T13:35:45Z",
-    "average_watts": 144.8,
-    "average_speed": 7.356,
-    "distance": 13954.6,
-    "moving_time": 1897,
-    "total_elevation_gain": 114.4
-  },
-  {
-    "start_date": "2021-11-08T06:29:06Z",
-    "average_watts": 156.6,
-    "average_speed": 5.735,
-    "distance": 7765.2,
-    "moving_time": 1354,
-    "total_elevation_gain": 68.2
-  },
-  {
-    "start_date": "2021-11-09T13:43:38Z",
-    "average_watts": 169.0,
-    "average_speed": 6.201,
-    "distance": 83320.2,
-    "moving_time": 13436,
-    "total_elevation_gain": 784.9
-  },
-  {
-    "start_date": "2021-11-10T15:04:42Z",
-    "average_watts": 176.5,
-    "average_speed": 8.13,
-    "distance": 19519.0,
-    "moving_time": 2401,
-    "total_elevation_gain": 200.6
-  },
-  {
-    "start_date": "2021-11-12T17:42:01Z",
-    "average_watts": 153.6,
-    "average_speed": 7.061,
-    "distance": 28991.1,
-    "moving_time": 4106,
-    "total_elevation_gain": 255.0
-  },
-  {
-    "start_date": "2021-11-13T17:25:15Z",
-    "average_watts": 141.1,
-    "average_speed": 6.027,
-    "distance": 53721.3,
-    "moving_time": 8913,
-    "total_elevation_gain": 650.1
-  },
-  {
-    "start_date": "2021-11-17T16:32:16Z",
-    "average_watts": 165.8,
-    "average_speed": 5.235,
-    "distance": 61714.5,
-    "moving_time": 11788,
-    "total_elevation_gain": 895.1
-  },
-  {
-    "start_date": "2021-11-19T17:52:43Z",
-    "average_watts": 177.3,
-    "average_speed": 5.913,
-    "distance": 7918.0,
-    "moving_time": 1339,
-    "total_elevation_gain": 56.4
-  },
-  {
-    "start_date": "2021-11-22T18:06:54Z",
-    "average_watts": 166.2,
-    "average_speed": 5.964,
-    "distance": 36419.8,
-    "moving_time": 6107,
-    "total_elevation_gain": 452.9
-  },
-  {
-    "start_date": "2021-11-23T08:32:18Z",
-    "average_watts": 159.6,
-    "average_speed": 7.232,
-    "distance": 11296.0,
-    "moving_time": 1562,
-    "total_elevation_gain": 102.4
-  },
-  {
-    "start_date": "2021-11-27T18:30:24Z",
-    "average_watts": 168.8,
-    "average_speed": 7.838,
-    "distance": 36711.8,
-    "moving_time": 4684,
-    "total_elevation_gain": 245.6
-  },
-  {
-    "start_date": "2021-11-28T18:44:00Z",
-    "average_watts": 139.9,
-    "average_speed": 5.95,
-    "distance": 50707.1,
-    "moving_time": 8522,
-    "total_elevation_gain": 539.5
-  },
-  {
-    "start_date": "2021-12-05T06:01:59Z",
-    "average_watts": 163.3,
-    "average_speed": 8.822,
-    "distance": 23546.8,
-    "moving_time": 2669,
-    "total_elevation_gain": 151.5
-  },
-  {
-    "start_date": "2021-12-08T08:49:03Z",
-    "average_watts": 155.9,
-    "average_speed": 9.214,
-    "distance": 19708.3,
-    "moving_time": 2139,
-    "total_elevation_gain": 128.7
-  },
-  {
-    "start_date": "2021-12-10T09:50:00Z",
-    "average_watts": 151.6,
-    "average_speed": 6.757,
-    "distance": 27259.7,
-    "moving_time": 4034,
-    "total_elevation_gain": 329.2
-  },
-  {
-    "start_date": "2021-12-12T16:20:33Z",
-    "average_watts": 142.6,
-    "average_speed": 7.76,
-    "distance": 21650.6,
-    "moving_time": 2790,
-    "total_elevation_gain": 222.3
-  },
-  {
-    "start_date": "2021-12-14T08:38:30Z",
-    "average_watts": 156.5,
-    "average_speed": 5.606,
-    "distance": 3469.8,
-    "moving_time": 619,
-    "total_elevation_gain": 36.2
-  },
-  {
-    "start_date": "2021-12-18T18:31:25Z",
-    "average_watts": 147.8,
-    "average_speed": 5.339,
-    "distance": 64554.2,
-    "moving_time": 12091,
-    "total_elevation_gain": 386.8
-  },
-  {
-    "start_date": "2021-12-19T07:44:45Z",
-    "average_watts": 161.3,
-    "average_speed": 6.174,
-    "distance": 59488.3,
-    "moving_time": 9636,
-    "total_elevation_gain": 743.7
-  },
-  {
-    "start_date": "2021-12-20T14:34:26Z",
-    "average_watts": 165.6,
-    "average_speed": 5.623,
-    "distance": 28445.8,
-    "moving_time": 5059,
-    "total_elevation_gain": 234.5
-  },
-  {
-    "start_date": "2021-12-21T13:51:56Z",
-    "average_watts": 158.4,
-    "average_speed": 6.209,
-    "distance": 82611.3,
-    "moving_time": 13306,
-    "total_elevation_gain": 810.9
-  },
-  {
-    "start_date": "2021-12-23T09:40:14Z",
-    "average_watts": 148.0,
-    "average_speed": 4.265,
-    "distance": 4708.3,
-    "moving_time": 1104,
-    "total_elevation_gain": 34.3
-  },
-  {
-    "start_date": "2021-12-24T18:44:17Z",
-    "average_watts": 157.0,
-    "average_speed": 8.102,
-    "distance": 24930.3,
-    "moving_time": 3077,
-    "total_elevation_gain": 214.4
-  },
-  {
-    "start_date": "2021-12-25T13:34:37Z",
-    "average_watts": 139.5,
-    "average_speed": 4.452,
-    "distance": 6833.9,
-    "moving_time": 1535,
-    "total_elevation_gain": 38.8
-  },
-  {
-    "start_date": "2021-12-26T14:23:25Z",
-    "average_watts": 141.6,
-    "average_speed": 6.898,
-    "distance": 27076.2,
-    "moving_time": 3925,
-    "total_elevation_gain": 167.7
-  },
-  {
-    "start_date": "2021-12-27T12:40:40Z",
-    "average_watts": 140.2,
-    "average_speed": 6.759,
-    "distance": 27855.7,
-    "moving_time": 4121,
-    "total_elevation_gain": 200.3
-  },
-  {
-    "start_date": "2021-12-29T15:41:30Z",
-    "average_watts": 143.1,
-    "average_speed": 9.13,
-    "distance": 18889.4,
-    "moving_time": 2069,
-    "total_elevation_gain": 209.6
-  },
-  {
-    "start_date": "2021-12-30T07:07:02Z",
-    "average_watts": 168.3,
-    "average_speed": 5.56,
-    "distance": 29647.9,
-    "moving_time": 5332,
-    "total_elevation_gain": 366.7
-  },
-  {
-    "start_date": "2022-01-01T18:11:13Z",
-    "average_watts": 141.4,
-    "average_speed": 9.667,
-    "distance": 16269.9,
-    "moving_time": 1683,
-    "total_elevation_gain": 111.5
-  },
-  {
-    "start_date": "2022-01-03T08:01:03Z",
-    "average_watts": 157.2,
-    "average_speed": 6.153,
-    "distance": 89360.3,
-    "moving_time": 14524,
-    "total_elevation_gain": 863.2
-  },
-  {
-    "start_date": "2022-01-04T06:50:33Z",
-    "average_watts": 149.4,
-    "average_speed": 8.414,
-    "distance": 19679.4,
-    "moving_time": 2339,
-    "total_elevation_gain": 223.1
-  },
-  {
-    "start_date": "2022-01-08T07:10:15Z",
-    "average_watts": 173.8,
-    "average_speed": 3.963,
-    "distance": 7379.3,
-    "moving_time": 1862,
-    "total_elevation_gain": 106.5
-  },
-  {
-    "start_date": "2022-01-09T06:57:56Z",
+    "average_speed": 7.62,
+    "distance": 37558.0,
+    "moving_time": 4929,
+    "total_elevation_gain": 368.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-08T17:20:43Z",
+    "average_watts": 132.5,
+    "average_speed": 7.209,
+    "distance": 13784.4,
+    "moving_time": 1912,
+    "total_elevation_gain": 177.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-09T19:44:53Z",
     "average_watts": 160.0,
-    "average_speed": 8.538,
-    "distance": 17119.2,
-    "moving_time": 2005,
-    "total_elevation_gain": 153.6
+    "average_speed": 9.018,
+    "distance": 15547.3,
+    "moving_time": 1724,
+    "total_elevation_gain": 101.5,
+    "type": "Ride"
   },
   {
-    "start_date": "2022-01-14T15:06:18Z",
-    "average_watts": 152.8,
-    "average_speed": 5.133,
-    "distance": 93391.3,
-    "moving_time": 18194,
-    "total_elevation_gain": 486.3
-  },
-  {
-    "start_date": "2022-01-17T06:33:50Z",
-    "average_watts": 153.8,
-    "average_speed": 9.403,
-    "distance": 17734.0,
-    "moving_time": 1886,
-    "total_elevation_gain": 216.0
-  },
-  {
-    "start_date": "2022-01-18T08:19:32Z",
-    "average_watts": 140.9,
-    "average_speed": 6.377,
-    "distance": 93037.5,
-    "moving_time": 14590,
-    "total_elevation_gain": 1148.4
-  },
-  {
-    "start_date": "2022-01-19T11:43:13Z",
-    "average_watts": 172.1,
-    "average_speed": 5.889,
-    "distance": 4145.9,
-    "moving_time": 704,
-    "total_elevation_gain": 30.5
-  },
-  {
-    "start_date": "2022-01-20T11:26:36Z",
-    "average_watts": 163.5,
-    "average_speed": 5.704,
-    "distance": 37592.1,
-    "moving_time": 6591,
-    "total_elevation_gain": 215.5
-  },
-  {
-    "start_date": "2022-01-22T06:03:43Z",
-    "average_watts": 160.4,
-    "average_speed": 7.858,
-    "distance": 39252.9,
-    "moving_time": 4995,
-    "total_elevation_gain": 202.7
-  },
-  {
-    "start_date": "2022-01-23T13:03:09Z",
-    "average_watts": 143.1,
-    "average_speed": 5.657,
-    "distance": 66884.0,
-    "moving_time": 11824,
-    "total_elevation_gain": 996.4
-  },
-  {
-    "start_date": "2022-01-24T08:51:15Z",
-    "average_watts": 144.7,
-    "average_speed": 5.986,
-    "distance": 6794.5,
-    "moving_time": 1135,
-    "total_elevation_gain": 57.0
-  },
-  {
-    "start_date": "2022-01-25T10:30:13Z",
-    "average_watts": 166.7,
-    "average_speed": 5.907,
-    "distance": 39433.5,
-    "moving_time": 6676,
-    "total_elevation_gain": 244.3
-  },
-  {
-    "start_date": "2022-01-26T10:41:56Z",
-    "average_watts": 159.0,
-    "average_speed": 9.689,
-    "distance": 22323.4,
-    "moving_time": 2304,
-    "total_elevation_gain": 283.3
-  },
-  {
-    "start_date": "2022-01-27T19:41:42Z",
-    "average_watts": 153.7,
-    "average_speed": 6.671,
-    "distance": 22902.7,
-    "moving_time": 3433,
-    "total_elevation_gain": 292.6
-  },
-  {
-    "start_date": "2022-01-28T09:14:46Z",
-    "average_watts": 144.8,
-    "average_speed": 6.485,
-    "distance": 55547.2,
-    "moving_time": 8566,
-    "total_elevation_gain": 486.7
-  },
-  {
-    "start_date": "2022-01-30T18:33:19Z",
-    "average_watts": 157.2,
-    "average_speed": 5.457,
-    "distance": 4747.7,
-    "moving_time": 870,
-    "total_elevation_gain": 28.2
-  },
-  {
-    "start_date": "2022-02-04T07:11:28Z",
-    "average_watts": 175.2,
-    "average_speed": 6.306,
-    "distance": 68440.6,
-    "moving_time": 10853,
-    "total_elevation_gain": 936.0
-  },
-  {
-    "start_date": "2022-02-05T12:23:35Z",
-    "average_watts": 142.1,
-    "average_speed": 7.476,
-    "distance": 38730.6,
-    "moving_time": 5181,
-    "total_elevation_gain": 390.3
-  },
-  {
-    "start_date": "2022-02-06T12:47:38Z",
-    "average_watts": 156.8,
-    "average_speed": 3.695,
-    "distance": 4374.6,
-    "moving_time": 1184,
-    "total_elevation_gain": 45.9
-  },
-  {
-    "start_date": "2022-02-10T11:23:33Z",
-    "average_watts": 154.3,
-    "average_speed": 6.854,
-    "distance": 99050.4,
-    "moving_time": 14451,
-    "total_elevation_gain": 742.4
-  },
-  {
-    "start_date": "2022-02-13T12:36:45Z",
-    "average_watts": 143.4,
-    "average_speed": 6.155,
-    "distance": 30090.3,
-    "moving_time": 4889,
-    "total_elevation_gain": 366.2
-  },
-  {
-    "start_date": "2022-02-15T07:39:11Z",
-    "average_watts": 170.4,
-    "average_speed": 5.87,
-    "distance": 83686.1,
-    "moving_time": 14257,
-    "total_elevation_gain": 581.7
-  },
-  {
-    "start_date": "2022-02-17T07:43:42Z",
-    "average_watts": 157.4,
-    "average_speed": 7.971,
-    "distance": 37455.9,
-    "moving_time": 4699,
-    "total_elevation_gain": 208.3
-  },
-  {
-    "start_date": "2022-02-18T14:59:52Z",
-    "average_watts": 157.0,
-    "average_speed": 5.771,
-    "distance": 95143.3,
-    "moving_time": 16487,
-    "total_elevation_gain": 1060.2
-  },
-  {
-    "start_date": "2022-02-19T08:22:28Z",
-    "average_watts": 163.0,
-    "average_speed": 7.033,
-    "distance": 20199.0,
-    "moving_time": 2872,
-    "total_elevation_gain": 201.8
-  },
-  {
-    "start_date": "2022-02-22T08:24:33Z",
-    "average_watts": 151.2,
-    "average_speed": 7.784,
-    "distance": 11698.8,
-    "moving_time": 1503,
-    "total_elevation_gain": 172.6
-  },
-  {
-    "start_date": "2022-02-23T19:23:12Z",
-    "average_watts": 140.8,
-    "average_speed": 5.023,
-    "distance": 23521.5,
-    "moving_time": 4683,
-    "total_elevation_gain": 205.8
-  },
-  {
-    "start_date": "2022-02-25T10:05:52Z",
-    "average_watts": 166.0,
-    "average_speed": 4.016,
-    "distance": 4654.0,
-    "moving_time": 1159,
-    "total_elevation_gain": 31.8
-  },
-  {
-    "start_date": "2022-02-26T11:05:17Z",
-    "average_watts": 140.5,
-    "average_speed": 5.557,
-    "distance": 3901.3,
-    "moving_time": 702,
-    "total_elevation_gain": 40.8
-  },
-  {
-    "start_date": "2022-02-28T06:17:51Z",
-    "average_watts": 142.4,
-    "average_speed": 5.909,
-    "distance": 26743.2,
-    "moving_time": 4526,
-    "total_elevation_gain": 381.8
-  },
-  {
-    "start_date": "2022-03-02T07:01:07Z",
-    "average_watts": 154.0,
-    "average_speed": 7.663,
-    "distance": 31079.5,
-    "moving_time": 4056,
-    "total_elevation_gain": 320.8
-  },
-  {
-    "start_date": "2022-03-03T09:21:15Z",
-    "average_watts": 171.5,
-    "average_speed": 6.554,
-    "distance": 81029.9,
-    "moving_time": 12363,
-    "total_elevation_gain": 616.2
-  },
-  {
-    "start_date": "2022-03-04T15:23:54Z",
-    "average_watts": 139.9,
-    "average_speed": 5.596,
-    "distance": 97849.9,
-    "moving_time": 17486,
-    "total_elevation_gain": 840.5
-  },
-  {
-    "start_date": "2022-03-06T11:22:43Z",
-    "average_watts": 176.3,
-    "average_speed": 8.294,
-    "distance": 23481.6,
-    "moving_time": 2831,
-    "total_elevation_gain": 125.6
-  },
-  {
-    "start_date": "2022-03-09T16:50:45Z",
-    "average_watts": 147.5,
-    "average_speed": 5.227,
-    "distance": 25628.0,
-    "moving_time": 4903,
-    "total_elevation_gain": 282.9
-  },
-  {
-    "start_date": "2022-03-10T13:07:39Z",
-    "average_watts": 161.8,
-    "average_speed": 5.032,
-    "distance": 56406.1,
-    "moving_time": 11210,
-    "total_elevation_gain": 325.0
-  },
-  {
-    "start_date": "2022-03-12T17:40:13Z",
-    "average_watts": 145.2,
-    "average_speed": 5.219,
-    "distance": 4869.0,
-    "moving_time": 933,
-    "total_elevation_gain": 26.6
-  },
-  {
-    "start_date": "2022-03-15T16:18:52Z",
-    "average_watts": 158.5,
-    "average_speed": 5.148,
-    "distance": 6481.3,
-    "moving_time": 1259,
-    "total_elevation_gain": 42.2
-  },
-  {
-    "start_date": "2022-03-18T18:17:26Z",
-    "average_watts": 178.8,
-    "average_speed": 5.917,
-    "distance": 34252.6,
-    "moving_time": 5789,
-    "total_elevation_gain": 273.1
-  },
-  {
-    "start_date": "2022-03-19T14:51:29Z",
-    "average_watts": 145.3,
-    "average_speed": 9.168,
-    "distance": 13936.0,
-    "moving_time": 1520,
-    "total_elevation_gain": 192.2
-  },
-  {
-    "start_date": "2022-03-20T16:59:20Z",
-    "average_watts": 166.4,
-    "average_speed": 5.079,
-    "distance": 90221.0,
-    "moving_time": 17762,
-    "total_elevation_gain": 479.1
-  },
-  {
-    "start_date": "2022-03-21T13:41:50Z",
-    "average_watts": 142.5,
-    "average_speed": 3.974,
-    "distance": 5186.2,
-    "moving_time": 1305,
-    "total_elevation_gain": 62.2
-  },
-  {
-    "start_date": "2022-03-22T17:41:57Z",
-    "average_watts": 159.6,
-    "average_speed": 6.405,
-    "distance": 53978.5,
-    "moving_time": 8427,
-    "total_elevation_gain": 357.9
-  },
-  {
-    "start_date": "2022-03-26T18:37:43Z",
-    "average_watts": 149.0,
-    "average_speed": 9.178,
-    "distance": 16272.5,
-    "moving_time": 1773,
-    "total_elevation_gain": 165.7
-  },
-  {
-    "start_date": "2022-03-28T14:27:58Z",
-    "average_watts": 170.3,
-    "average_speed": 6.695,
-    "distance": 38498.5,
-    "moving_time": 5750,
-    "total_elevation_gain": 521.1
-  },
-  {
-    "start_date": "2022-03-30T18:42:36Z",
-    "average_watts": 144.3,
-    "average_speed": 6.026,
-    "distance": 51356.6,
-    "moving_time": 8522,
-    "total_elevation_gain": 700.3
-  },
-  {
-    "start_date": "2022-03-31T11:59:40Z",
-    "average_watts": 174.4,
-    "average_speed": 7.172,
-    "distance": 39314.7,
-    "moving_time": 5482,
-    "total_elevation_gain": 348.3
-  },
-  {
-    "start_date": "2022-04-03T10:43:27Z",
-    "average_watts": 143.3,
-    "average_speed": 9.652,
-    "distance": 14101.2,
-    "moving_time": 1461,
-    "total_elevation_gain": 97.1
-  },
-  {
-    "start_date": "2022-04-05T16:41:08Z",
-    "average_watts": 159.8,
-    "average_speed": 5.384,
-    "distance": 87445.2,
-    "moving_time": 16241,
-    "total_elevation_gain": 479.1
-  },
-  {
-    "start_date": "2022-04-07T07:24:37Z",
-    "average_watts": 164.1,
-    "average_speed": 6.74,
-    "distance": 57947.6,
-    "moving_time": 8598,
-    "total_elevation_gain": 372.4
-  },
-  {
-    "start_date": "2022-04-10T15:27:25Z",
-    "average_watts": 169.7,
-    "average_speed": 9.345,
-    "distance": 11914.9,
-    "moving_time": 1275,
-    "total_elevation_gain": 95.4
-  },
-  {
-    "start_date": "2022-04-11T16:39:43Z",
-    "average_watts": 158.9,
-    "average_speed": 3.297,
-    "distance": 6291.4,
-    "moving_time": 1908,
-    "total_elevation_gain": 69.7
-  },
-  {
-    "start_date": "2022-04-12T18:24:44Z",
-    "average_watts": 147.9,
-    "average_speed": 8.436,
-    "distance": 22710.9,
-    "moving_time": 2692,
-    "total_elevation_gain": 236.0
-  },
-  {
-    "start_date": "2022-04-13T19:43:56Z",
-    "average_watts": 144.3,
-    "average_speed": 7.435,
-    "distance": 24446.9,
-    "moving_time": 3288,
-    "total_elevation_gain": 170.4
-  },
-  {
-    "start_date": "2022-04-16T07:14:53Z",
-    "average_watts": 169.7,
-    "average_speed": 3.576,
-    "distance": 4612.5,
-    "moving_time": 1290,
-    "total_elevation_gain": 49.4
-  },
-  {
-    "start_date": "2022-04-18T15:17:01Z",
-    "average_watts": 160.3,
-    "average_speed": 5.593,
-    "distance": 5352.3,
-    "moving_time": 957,
-    "total_elevation_gain": 73.1
-  },
-  {
-    "start_date": "2022-04-19T09:53:12Z",
-    "average_watts": 179.5,
-    "average_speed": 3.319,
-    "distance": 7275.6,
-    "moving_time": 2192,
-    "total_elevation_gain": 76.6
-  },
-  {
-    "start_date": "2022-04-20T15:54:22Z",
-    "average_watts": 167.0,
-    "average_speed": 8.167,
-    "distance": 23307.6,
-    "moving_time": 2854,
-    "total_elevation_gain": 149.0
-  },
-  {
-    "start_date": "2022-04-21T16:37:37Z",
-    "average_watts": 168.2,
-    "average_speed": 5.17,
-    "distance": 95936.2,
-    "moving_time": 18558,
-    "total_elevation_gain": 537.1
-  },
-  {
-    "start_date": "2022-04-22T06:02:44Z",
-    "average_watts": 178.3,
-    "average_speed": 6.659,
-    "distance": 23314.8,
-    "moving_time": 3501,
-    "total_elevation_gain": 192.4
-  },
-  {
-    "start_date": "2022-04-24T16:20:28Z",
-    "average_watts": 178.4,
-    "average_speed": 4.391,
-    "distance": 6613.0,
-    "moving_time": 1506,
-    "total_elevation_gain": 39.1
-  },
-  {
-    "start_date": "2022-04-27T07:42:30Z",
-    "average_watts": 169.0,
-    "average_speed": 9.522,
-    "distance": 13711.9,
-    "moving_time": 1440,
-    "total_elevation_gain": 140.3
-  },
-  {
-    "start_date": "2022-04-28T10:00:02Z",
-    "average_watts": 152.5,
-    "average_speed": 7.671,
-    "distance": 17252.1,
-    "moving_time": 2249,
-    "total_elevation_gain": 250.3
-  },
-  {
-    "start_date": "2022-04-30T19:34:18Z",
-    "average_watts": 150.9,
-    "average_speed": 5.618,
-    "distance": 5573.2,
-    "moving_time": 992,
-    "total_elevation_gain": 59.4
-  },
-  {
-    "start_date": "2022-05-01T13:48:30Z",
-    "average_watts": 149.7,
-    "average_speed": 8.533,
-    "distance": 19131.6,
-    "moving_time": 2242,
-    "total_elevation_gain": 182.4
-  },
-  {
-    "start_date": "2022-05-02T13:13:49Z",
-    "average_watts": 165.6,
-    "average_speed": 7.109,
-    "distance": 36527.1,
-    "moving_time": 5138,
-    "total_elevation_gain": 189.0
-  },
-  {
-    "start_date": "2022-05-03T10:26:32Z",
-    "average_watts": 179.4,
-    "average_speed": 8.107,
-    "distance": 18856.4,
-    "moving_time": 2326,
-    "total_elevation_gain": 97.4
-  },
-  {
-    "start_date": "2022-05-05T12:04:42Z",
-    "average_watts": 163.6,
-    "average_speed": 4.321,
-    "distance": 6957.6,
-    "moving_time": 1610,
-    "total_elevation_gain": 48.7
-  },
-  {
-    "start_date": "2022-05-07T14:51:15Z",
-    "average_watts": 140.8,
-    "average_speed": 5.352,
-    "distance": 7423.2,
-    "moving_time": 1387,
-    "total_elevation_gain": 98.6
-  },
-  {
-    "start_date": "2022-05-09T19:05:19Z",
-    "average_watts": 140.7,
-    "average_speed": 8.412,
-    "distance": 13972.0,
-    "moving_time": 1661,
-    "total_elevation_gain": 195.0
-  },
-  {
-    "start_date": "2022-05-10T06:53:53Z",
-    "average_watts": 160.2,
-    "average_speed": 7.17,
-    "distance": 12167.9,
-    "moving_time": 1697,
-    "total_elevation_gain": 178.6
-  },
-  {
-    "start_date": "2022-05-13T08:47:07Z",
-    "average_watts": 164.9,
-    "average_speed": 9.614,
-    "distance": 15871.9,
-    "moving_time": 1651,
-    "total_elevation_gain": 236.9
-  },
-  {
-    "start_date": "2022-05-17T15:48:23Z",
-    "average_watts": 156.6,
-    "average_speed": 5.711,
-    "distance": 57740.7,
-    "moving_time": 10111,
-    "total_elevation_gain": 313.2
-  },
-  {
-    "start_date": "2022-05-18T19:07:55Z",
-    "average_watts": 145.4,
-    "average_speed": 3.773,
-    "distance": 7036.4,
-    "moving_time": 1865,
-    "total_elevation_gain": 87.8
-  },
-  {
-    "start_date": "2022-05-19T06:29:14Z",
-    "average_watts": 174.7,
-    "average_speed": 6.221,
-    "distance": 78775.1,
-    "moving_time": 12663,
-    "total_elevation_gain": 904.9
-  },
-  {
-    "start_date": "2022-05-23T17:49:30Z",
-    "average_watts": 173.3,
-    "average_speed": 5.926,
-    "distance": 35696.2,
-    "moving_time": 6024,
-    "total_elevation_gain": 307.0
-  },
-  {
-    "start_date": "2022-05-24T12:19:19Z",
-    "average_watts": 165.5,
-    "average_speed": 7.464,
-    "distance": 13106.6,
-    "moving_time": 1756,
-    "total_elevation_gain": 82.3
-  },
-  {
-    "start_date": "2022-05-25T14:03:14Z",
-    "average_watts": 148.7,
-    "average_speed": 5.112,
-    "distance": 21511.8,
-    "moving_time": 4208,
-    "total_elevation_gain": 174.1
-  },
-  {
-    "start_date": "2022-05-26T19:03:17Z",
-    "average_watts": 153.7,
-    "average_speed": 6.243,
-    "distance": 20883.5,
-    "moving_time": 3345,
-    "total_elevation_gain": 143.4
-  },
-  {
-    "start_date": "2022-05-28T08:46:31Z",
-    "average_watts": 144.7,
-    "average_speed": 9.743,
-    "distance": 10990.2,
-    "moving_time": 1128,
-    "total_elevation_gain": 80.1
-  },
-  {
-    "start_date": "2022-05-29T15:44:18Z",
-    "average_watts": 175.7,
-    "average_speed": 5.569,
-    "distance": 34357.5,
-    "moving_time": 6169,
-    "total_elevation_gain": 310.5
-  },
-  {
-    "start_date": "2022-05-30T18:55:50Z",
-    "average_watts": 156.7,
-    "average_speed": 5.126,
-    "distance": 71015.7,
-    "moving_time": 13855,
-    "total_elevation_gain": 665.3
-  },
-  {
-    "start_date": "2022-05-31T18:55:50Z",
-    "average_watts": 161.7,
-    "average_speed": 5.567,
-    "distance": 3395.7,
-    "moving_time": 610,
-    "total_elevation_gain": 37.7
-  },
-  {
-    "start_date": "2022-06-02T12:47:12Z",
-    "average_watts": 162.9,
-    "average_speed": 6.886,
-    "distance": 83714.0,
-    "moving_time": 12158,
-    "total_elevation_gain": 1028.4
-  },
-  {
-    "start_date": "2022-06-05T13:17:18Z",
-    "average_watts": 153.2,
-    "average_speed": 5.445,
-    "distance": 25894.5,
-    "moving_time": 4756,
-    "total_elevation_gain": 323.2
-  },
-  {
-    "start_date": "2022-06-06T13:22:20Z",
-    "average_watts": 166.5,
-    "average_speed": 4.978,
-    "distance": 4499.8,
-    "moving_time": 904,
-    "total_elevation_gain": 41.6
-  },
-  {
-    "start_date": "2022-06-07T07:56:13Z",
-    "average_watts": 174.5,
-    "average_speed": 7.767,
-    "distance": 16574.1,
-    "moving_time": 2134,
-    "total_elevation_gain": 194.8
-  },
-  {
-    "start_date": "2022-06-14T08:31:27Z",
-    "average_watts": 160.5,
-    "average_speed": 5.138,
-    "distance": 52751.7,
-    "moving_time": 10267,
-    "total_elevation_gain": 601.6
-  },
-  {
-    "start_date": "2022-06-18T11:35:31Z",
-    "average_watts": 147.8,
-    "average_speed": 5.481,
-    "distance": 63576.8,
-    "moving_time": 11599,
-    "total_elevation_gain": 339.5
-  },
-  {
-    "start_date": "2022-06-19T15:10:13Z",
-    "average_watts": 168.9,
-    "average_speed": 5.173,
-    "distance": 39730.5,
-    "moving_time": 7681,
-    "total_elevation_gain": 523.4
-  },
-  {
-    "start_date": "2022-06-21T07:04:00Z",
-    "average_watts": 149.1,
-    "average_speed": 6.247,
-    "distance": 96686.7,
-    "moving_time": 15477,
-    "total_elevation_gain": 1224.4
-  },
-  {
-    "start_date": "2022-06-25T08:54:12Z",
-    "average_watts": 147.2,
-    "average_speed": 6.397,
-    "distance": 38697.7,
-    "moving_time": 6049,
-    "total_elevation_gain": 306.1
-  },
-  {
-    "start_date": "2022-06-26T07:35:56Z",
-    "average_watts": 174.3,
-    "average_speed": 5.129,
-    "distance": 6836.8,
-    "moving_time": 1333,
-    "total_elevation_gain": 70.9
-  },
-  {
-    "start_date": "2022-06-27T08:25:29Z",
-    "average_watts": 150.0,
-    "average_speed": 5.589,
-    "distance": 21541.3,
-    "moving_time": 3854,
-    "total_elevation_gain": 143.5
-  },
-  {
-    "start_date": "2022-06-28T15:24:28Z",
-    "average_watts": 144.1,
-    "average_speed": 7.753,
-    "distance": 15675.9,
-    "moving_time": 2022,
-    "total_elevation_gain": 117.0
-  },
-  {
-    "start_date": "2022-07-02T06:32:13Z",
-    "average_watts": 163.8,
-    "average_speed": 5.916,
-    "distance": 63915.1,
-    "moving_time": 10803,
-    "total_elevation_gain": 476.0
-  },
-  {
-    "start_date": "2022-07-07T14:24:54Z",
-    "average_watts": 158.4,
-    "average_speed": 3.652,
-    "distance": 5281.2,
-    "moving_time": 1446,
-    "total_elevation_gain": 75.5
-  },
-  {
-    "start_date": "2022-07-11T10:52:40Z",
-    "average_watts": 170.8,
-    "average_speed": 6.276,
-    "distance": 60453.3,
-    "moving_time": 9633,
-    "total_elevation_gain": 554.0
-  },
-  {
-    "start_date": "2022-07-12T12:54:05Z",
-    "average_watts": 155.1,
-    "average_speed": 9.57,
-    "distance": 23332.1,
-    "moving_time": 2438,
-    "total_elevation_gain": 310.1
-  },
-  {
-    "start_date": "2022-07-14T18:31:26Z",
-    "average_watts": 172.7,
-    "average_speed": 5.253,
-    "distance": 88784.3,
-    "moving_time": 16902,
-    "total_elevation_gain": 1036.5
-  },
-  {
-    "start_date": "2022-07-21T13:25:08Z",
-    "average_watts": 158.6,
-    "average_speed": 6.931,
-    "distance": 86199.8,
-    "moving_time": 12436,
-    "total_elevation_gain": 1173.0
-  },
-  {
-    "start_date": "2022-07-22T15:40:45Z",
+    "start_date": "2020-05-10T06:35:49Z",
     "average_watts": 149.4,
-    "average_speed": 9.273,
-    "distance": 12017.4,
-    "moving_time": 1296,
-    "total_elevation_gain": 117.1
+    "average_speed": 9.267,
+    "distance": 13779.6,
+    "moving_time": 1487,
+    "total_elevation_gain": 176.5,
+    "type": "Ride"
   },
   {
-    "start_date": "2022-07-25T11:03:03Z",
-    "average_watts": 171.5,
-    "average_speed": 6.16,
-    "distance": 58580.5,
-    "moving_time": 9510,
-    "total_elevation_gain": 450.5
-  },
-  {
-    "start_date": "2022-07-30T17:41:29Z",
-    "average_watts": 166.7,
-    "average_speed": 7.548,
-    "distance": 29084.0,
-    "moving_time": 3853,
-    "total_elevation_gain": 226.2
-  },
-  {
-    "start_date": "2022-07-31T13:41:44Z",
-    "average_watts": 145.4,
-    "average_speed": 4.348,
-    "distance": 3574.0,
-    "moving_time": 822,
-    "total_elevation_gain": 23.0
-  },
-  {
-    "start_date": "2022-08-01T10:23:49Z",
-    "average_watts": 181.0,
-    "average_speed": 3.795,
-    "distance": 4652.7,
-    "moving_time": 1226,
-    "total_elevation_gain": 67.8
-  },
-  {
-    "start_date": "2022-08-05T14:04:33Z",
-    "average_watts": 171.1,
-    "average_speed": 5.882,
-    "distance": 75353.3,
-    "moving_time": 12810,
-    "total_elevation_gain": 938.7
-  },
-  {
-    "start_date": "2022-08-09T17:25:26Z",
-    "average_watts": 149.2,
-    "average_speed": 6.373,
-    "distance": 87055.0,
-    "moving_time": 13661,
-    "total_elevation_gain": 1251.3
-  },
-  {
-    "start_date": "2022-08-10T08:58:35Z",
-    "average_watts": 142.9,
-    "average_speed": 4.809,
-    "distance": 3395.4,
-    "moving_time": 706,
-    "total_elevation_gain": 18.1
-  },
-  {
-    "start_date": "2022-08-11T10:57:22Z",
-    "average_watts": 163.8,
-    "average_speed": 7.886,
-    "distance": 16947.6,
-    "moving_time": 2149,
-    "total_elevation_gain": 235.0
-  },
-  {
-    "start_date": "2022-08-12T06:48:05Z",
-    "average_watts": 152.9,
-    "average_speed": 6.767,
-    "distance": 62448.2,
-    "moving_time": 9228,
-    "total_elevation_gain": 766.0
-  },
-  {
-    "start_date": "2022-08-13T11:14:19Z",
-    "average_watts": 164.3,
-    "average_speed": 7.592,
-    "distance": 22358.9,
-    "moving_time": 2945,
-    "total_elevation_gain": 292.3
-  },
-  {
-    "start_date": "2022-08-15T10:39:40Z",
-    "average_watts": 156.7,
-    "average_speed": 9.717,
-    "distance": 23894.2,
-    "moving_time": 2459,
-    "total_elevation_gain": 234.9
-  },
-  {
-    "start_date": "2022-08-16T17:04:27Z",
-    "average_watts": 164.5,
-    "average_speed": 5.397,
-    "distance": 30991.9,
-    "moving_time": 5742,
-    "total_elevation_gain": 209.6
-  },
-  {
-    "start_date": "2022-08-17T19:56:12Z",
-    "average_watts": 142.3,
-    "average_speed": 9.322,
-    "distance": 18820.9,
-    "moving_time": 2019,
-    "total_elevation_gain": 201.7
-  },
-  {
-    "start_date": "2022-08-19T09:55:32Z",
-    "average_watts": 151.5,
-    "average_speed": 8.177,
-    "distance": 24826.9,
-    "moving_time": 3036,
-    "total_elevation_gain": 172.9
-  },
-  {
-    "start_date": "2022-08-23T09:25:15Z",
-    "average_watts": 179.5,
-    "average_speed": 5.899,
-    "distance": 62413.5,
-    "moving_time": 10581,
-    "total_elevation_gain": 924.5
-  },
-  {
-    "start_date": "2022-08-24T16:17:52Z",
-    "average_watts": 166.6,
-    "average_speed": 5.906,
-    "distance": 83379.1,
-    "moving_time": 14117,
-    "total_elevation_gain": 701.0
-  },
-  {
-    "start_date": "2022-08-27T17:40:07Z",
-    "average_watts": 162.1,
-    "average_speed": 5.362,
-    "distance": 31710.1,
-    "moving_time": 5914,
-    "total_elevation_gain": 374.1
-  },
-  {
-    "start_date": "2022-08-31T19:11:50Z",
-    "average_watts": 148.2,
-    "average_speed": 5.159,
-    "distance": 3802.5,
-    "moving_time": 737,
-    "total_elevation_gain": 46.6
-  },
-  {
-    "start_date": "2022-09-01T11:25:10Z",
-    "average_watts": 181.6,
-    "average_speed": 7.187,
-    "distance": 35556.4,
-    "moving_time": 4947,
-    "total_elevation_gain": 494.6
-  },
-  {
-    "start_date": "2022-09-02T07:11:18Z",
-    "average_watts": 166.6,
-    "average_speed": 9.596,
-    "distance": 14604.7,
-    "moving_time": 1522,
-    "total_elevation_gain": 168.7
-  },
-  {
-    "start_date": "2022-09-03T12:55:39Z",
-    "average_watts": 169.4,
-    "average_speed": 7.757,
-    "distance": 24596.8,
-    "moving_time": 3171,
-    "total_elevation_gain": 179.5
-  },
-  {
-    "start_date": "2022-09-04T14:53:08Z",
-    "average_watts": 179.9,
-    "average_speed": 5.115,
-    "distance": 27647.0,
-    "moving_time": 5405,
-    "total_elevation_gain": 228.5
-  },
-  {
-    "start_date": "2022-09-05T08:01:11Z",
-    "average_watts": 143.2,
-    "average_speed": 5.827,
-    "distance": 91531.5,
-    "moving_time": 15709,
-    "total_elevation_gain": 591.6
-  },
-  {
-    "start_date": "2022-09-06T17:20:41Z",
-    "average_watts": 174.0,
-    "average_speed": 4.337,
-    "distance": 3487.3,
-    "moving_time": 804,
-    "total_elevation_gain": 50.7
-  },
-  {
-    "start_date": "2022-09-13T18:24:40Z",
-    "average_watts": 170.7,
-    "average_speed": 4.807,
-    "distance": 6820.7,
-    "moving_time": 1419,
-    "total_elevation_gain": 84.5
-  },
-  {
-    "start_date": "2022-09-14T15:09:02Z",
-    "average_watts": 162.5,
-    "average_speed": 6.591,
-    "distance": 28163.0,
-    "moving_time": 4273,
-    "total_elevation_gain": 328.2
-  },
-  {
-    "start_date": "2022-09-15T16:48:08Z",
-    "average_watts": 149.9,
-    "average_speed": 9.728,
-    "distance": 19698.7,
-    "moving_time": 2025,
-    "total_elevation_gain": 252.2
-  },
-  {
-    "start_date": "2022-09-16T13:35:16Z",
-    "average_watts": 173.7,
-    "average_speed": 4.566,
-    "distance": 5684.9,
-    "moving_time": 1245,
-    "total_elevation_gain": 51.2
-  },
-  {
-    "start_date": "2022-09-17T15:52:07Z",
-    "average_watts": 145.1,
-    "average_speed": 6.354,
-    "distance": 58808.2,
-    "moving_time": 9255,
-    "total_elevation_gain": 524.0
-  },
-  {
-    "start_date": "2022-09-22T07:22:51Z",
-    "average_watts": 167.0,
-    "average_speed": 7.943,
-    "distance": 27148.8,
-    "moving_time": 3418,
-    "total_elevation_gain": 327.5
-  },
-  {
-    "start_date": "2022-09-23T14:19:48Z",
-    "average_watts": 173.9,
-    "average_speed": 6.504,
-    "distance": 22718.3,
-    "moving_time": 3493,
-    "total_elevation_gain": 258.3
-  },
-  {
-    "start_date": "2022-09-25T17:56:25Z",
-    "average_watts": 152.4,
-    "average_speed": 9.511,
-    "distance": 10918.7,
-    "moving_time": 1148,
-    "total_elevation_gain": 103.2
-  },
-  {
-    "start_date": "2022-09-28T07:46:07Z",
-    "average_watts": 181.1,
-    "average_speed": 5.134,
-    "distance": 70272.9,
-    "moving_time": 13687,
-    "total_elevation_gain": 447.9
-  },
-  {
-    "start_date": "2022-09-29T11:40:23Z",
-    "average_watts": 172.5,
-    "average_speed": 5.32,
-    "distance": 24241.8,
-    "moving_time": 4557,
-    "total_elevation_gain": 150.2
-  },
-  {
-    "start_date": "2022-09-30T15:05:51Z",
-    "average_watts": 167.2,
-    "average_speed": 3.006,
-    "distance": 6838.5,
-    "moving_time": 2275,
-    "total_elevation_gain": 94.4
-  },
-  {
-    "start_date": "2022-10-01T13:54:47Z",
-    "average_watts": 178.7,
-    "average_speed": 5.308,
-    "distance": 78441.7,
-    "moving_time": 14778,
-    "total_elevation_gain": 1063.7
-  },
-  {
-    "start_date": "2022-10-05T16:11:25Z",
-    "average_watts": 164.9,
-    "average_speed": 3.734,
-    "distance": 4724.1,
-    "moving_time": 1265,
-    "total_elevation_gain": 38.1
-  },
-  {
-    "start_date": "2022-10-06T10:35:19Z",
-    "average_watts": 157.7,
-    "average_speed": 9.496,
-    "distance": 15439.8,
-    "moving_time": 1626,
-    "total_elevation_gain": 90.6
-  },
-  {
-    "start_date": "2022-10-08T13:52:03Z",
-    "average_watts": 157.4,
-    "average_speed": 7.205,
-    "distance": 28358.0,
-    "moving_time": 3936,
-    "total_elevation_gain": 323.7
-  },
-  {
-    "start_date": "2022-10-10T10:31:54Z",
-    "average_watts": 157.2,
-    "average_speed": 5.78,
-    "distance": 39190.4,
-    "moving_time": 6780,
-    "total_elevation_gain": 275.3
-  },
-  {
-    "start_date": "2022-10-14T19:59:54Z",
-    "average_watts": 166.7,
-    "average_speed": 5.459,
-    "distance": 3117.3,
-    "moving_time": 571,
-    "total_elevation_gain": 40.9
-  },
-  {
-    "start_date": "2022-10-17T06:42:22Z",
-    "average_watts": 182.1,
-    "average_speed": 5.628,
-    "distance": 62058.6,
-    "moving_time": 11027,
-    "total_elevation_gain": 429.4
-  },
-  {
-    "start_date": "2022-10-27T11:52:29Z",
-    "average_watts": 174.9,
-    "average_speed": 4.716,
-    "distance": 7805.8,
-    "moving_time": 1655,
-    "total_elevation_gain": 81.2
-  },
-  {
-    "start_date": "2022-10-29T09:52:47Z",
-    "average_watts": 168.2,
-    "average_speed": 9.866,
-    "distance": 23441.5,
-    "moving_time": 2376,
-    "total_elevation_gain": 149.9
-  },
-  {
-    "start_date": "2022-10-31T16:07:13Z",
-    "average_watts": 159.6,
-    "average_speed": 7.308,
-    "distance": 18183.4,
-    "moving_time": 2488,
-    "total_elevation_gain": 264.5
-  },
-  {
-    "start_date": "2022-11-05T16:17:34Z",
-    "average_watts": 158.8,
-    "average_speed": 3.515,
-    "distance": 5359.7,
-    "moving_time": 1525,
-    "total_elevation_gain": 48.3
-  },
-  {
-    "start_date": "2022-11-09T17:04:18Z",
-    "average_watts": 161.7,
-    "average_speed": 4.101,
-    "distance": 6946.4,
-    "moving_time": 1694,
-    "total_elevation_gain": 101.5
-  },
-  {
-    "start_date": "2022-11-10T19:32:12Z",
-    "average_watts": 174.0,
-    "average_speed": 5.016,
-    "distance": 66899.3,
-    "moving_time": 13336,
-    "total_elevation_gain": 929.5
-  },
-  {
-    "start_date": "2022-11-12T06:42:01Z",
-    "average_watts": 146.4,
-    "average_speed": 5.47,
-    "distance": 7750.5,
-    "moving_time": 1417,
-    "total_elevation_gain": 48.6
-  },
-  {
-    "start_date": "2022-11-14T14:02:09Z",
-    "average_watts": 173.0,
-    "average_speed": 7.961,
-    "distance": 22703.9,
-    "moving_time": 2852,
-    "total_elevation_gain": 314.4
-  },
-  {
-    "start_date": "2022-11-15T09:38:35Z",
-    "average_watts": 172.8,
-    "average_speed": 7.68,
-    "distance": 28615.1,
-    "moving_time": 3726,
-    "total_elevation_gain": 190.9
-  },
-  {
-    "start_date": "2022-11-16T13:58:26Z",
-    "average_watts": 167.1,
-    "average_speed": 5.255,
-    "distance": 78000.7,
-    "moving_time": 14842,
-    "total_elevation_gain": 455.8
-  },
-  {
-    "start_date": "2022-11-17T09:50:13Z",
-    "average_watts": 143.1,
-    "average_speed": 9.694,
-    "distance": 24001.7,
-    "moving_time": 2476,
-    "total_elevation_gain": 290.4
-  },
-  {
-    "start_date": "2022-11-19T12:02:47Z",
-    "average_watts": 168.2,
-    "average_speed": 6.227,
-    "distance": 39691.6,
-    "moving_time": 6374,
-    "total_elevation_gain": 474.0
-  },
-  {
-    "start_date": "2022-11-21T07:05:43Z",
-    "average_watts": 176.3,
-    "average_speed": 8.035,
-    "distance": 19669.3,
-    "moving_time": 2448,
-    "total_elevation_gain": 145.5
-  },
-  {
-    "start_date": "2022-11-22T09:58:22Z",
-    "average_watts": 164.8,
-    "average_speed": 6.754,
-    "distance": 98806.6,
-    "moving_time": 14630,
-    "total_elevation_gain": 958.9
-  },
-  {
-    "start_date": "2022-11-24T14:18:19Z",
-    "average_watts": 165.7,
-    "average_speed": 7.648,
-    "distance": 25399.1,
-    "moving_time": 3321,
-    "total_elevation_gain": 273.0
-  },
-  {
-    "start_date": "2022-11-30T18:51:53Z",
-    "average_watts": 169.7,
-    "average_speed": 6.839,
-    "distance": 50256.3,
-    "moving_time": 7349,
-    "total_elevation_gain": 442.5
-  },
-  {
-    "start_date": "2022-12-01T11:54:50Z",
-    "average_watts": 161.7,
-    "average_speed": 5.965,
-    "distance": 27068.9,
-    "moving_time": 4538,
-    "total_elevation_gain": 263.0
-  },
-  {
-    "start_date": "2022-12-02T08:41:32Z",
-    "average_watts": 169.9,
-    "average_speed": 3.807,
-    "distance": 7822.7,
-    "moving_time": 2055,
-    "total_elevation_gain": 46.4
-  },
-  {
-    "start_date": "2022-12-09T10:59:47Z",
-    "average_watts": 147.6,
-    "average_speed": 6.796,
-    "distance": 36665.2,
-    "moving_time": 5395,
-    "total_elevation_gain": 209.9
-  },
-  {
-    "start_date": "2022-12-12T15:55:52Z",
-    "average_watts": 162.4,
-    "average_speed": 4.062,
-    "distance": 6247.6,
-    "moving_time": 1538,
-    "total_elevation_gain": 84.2
-  },
-  {
-    "start_date": "2022-12-18T14:42:43Z",
-    "average_watts": 158.2,
-    "average_speed": 4.859,
-    "distance": 7002.1,
-    "moving_time": 1441,
-    "total_elevation_gain": 38.3
-  },
-  {
-    "start_date": "2022-12-19T15:54:04Z",
-    "average_watts": 159.1,
-    "average_speed": 5.239,
-    "distance": 24171.3,
-    "moving_time": 4614,
-    "total_elevation_gain": 334.9
-  },
-  {
-    "start_date": "2022-12-20T06:50:24Z",
-    "average_watts": 160.4,
-    "average_speed": 6.275,
-    "distance": 55807.2,
-    "moving_time": 8893,
-    "total_elevation_gain": 676.2
-  },
-  {
-    "start_date": "2022-12-21T12:59:55Z",
-    "average_watts": 167.8,
-    "average_speed": 4.98,
-    "distance": 7430.3,
-    "moving_time": 1492,
-    "total_elevation_gain": 88.1
-  },
-  {
-    "start_date": "2022-12-26T13:51:07Z",
-    "average_watts": 160.5,
-    "average_speed": 9.847,
-    "distance": 19822.9,
-    "moving_time": 2013,
-    "total_elevation_gain": 173.5
-  },
-  {
-    "start_date": "2022-12-27T12:00:58Z",
-    "average_watts": 181.2,
-    "average_speed": 3.273,
-    "distance": 4012.2,
-    "moving_time": 1226,
-    "total_elevation_gain": 55.2
-  },
-  {
-    "start_date": "2022-12-29T09:27:31Z",
-    "average_watts": 178.1,
-    "average_speed": 7.886,
-    "distance": 22229.9,
-    "moving_time": 2819,
-    "total_elevation_gain": 149.3
-  },
-  {
-    "start_date": "2023-01-03T06:49:58Z",
-    "average_watts": 157.7,
-    "average_speed": 4.923,
-    "distance": 4992.3,
-    "moving_time": 1014,
-    "total_elevation_gain": 27.7
-  },
-  {
-    "start_date": "2023-01-04T12:08:00Z",
-    "average_watts": 176.0,
-    "average_speed": 7.79,
-    "distance": 26003.9,
-    "moving_time": 3338,
-    "total_elevation_gain": 366.1
-  },
-  {
-    "start_date": "2023-01-05T16:28:01Z",
-    "average_watts": 146.1,
-    "average_speed": 8.315,
-    "distance": 12747.1,
-    "moving_time": 1533,
-    "total_elevation_gain": 159.3
-  },
-  {
-    "start_date": "2023-01-06T18:17:43Z",
-    "average_watts": 167.6,
-    "average_speed": 8.252,
-    "distance": 19466.4,
-    "moving_time": 2359,
-    "total_elevation_gain": 291.7
-  },
-  {
-    "start_date": "2023-01-07T08:14:27Z",
-    "average_watts": 148.0,
-    "average_speed": 3.132,
-    "distance": 7099.9,
-    "moving_time": 2267,
-    "total_elevation_gain": 73.5
-  },
-  {
-    "start_date": "2023-01-08T13:21:16Z",
-    "average_watts": 154.3,
-    "average_speed": 6.213,
-    "distance": 89993.9,
-    "moving_time": 14484,
-    "total_elevation_gain": 806.1
-  },
-  {
-    "start_date": "2023-01-11T10:41:21Z",
-    "average_watts": 178.3,
-    "average_speed": 6.362,
-    "distance": 24250.8,
-    "moving_time": 3812,
-    "total_elevation_gain": 165.5
-  },
-  {
-    "start_date": "2023-01-12T11:42:36Z",
-    "average_watts": 170.9,
-    "average_speed": 6.583,
-    "distance": 84436.3,
-    "moving_time": 12827,
-    "total_elevation_gain": 433.7
-  },
-  {
-    "start_date": "2023-01-13T18:32:41Z",
-    "average_watts": 182.8,
-    "average_speed": 3.479,
-    "distance": 7821.6,
-    "moving_time": 2248,
-    "total_elevation_gain": 58.2
-  },
-  {
-    "start_date": "2023-01-14T19:22:18Z",
-    "average_watts": 152.5,
-    "average_speed": 6.924,
-    "distance": 38003.4,
-    "moving_time": 5489,
-    "total_elevation_gain": 561.9
-  },
-  {
-    "start_date": "2023-01-15T19:33:03Z",
-    "average_watts": 179.8,
-    "average_speed": 6.997,
-    "distance": 97027.7,
-    "moving_time": 13868,
-    "total_elevation_gain": 1289.3
-  },
-  {
-    "start_date": "2023-01-19T13:42:40Z",
-    "average_watts": 153.9,
-    "average_speed": 4.477,
-    "distance": 6192.1,
-    "moving_time": 1383,
-    "total_elevation_gain": 49.3
-  },
-  {
-    "start_date": "2023-01-20T06:29:39Z",
-    "average_watts": 167.8,
-    "average_speed": 6.464,
-    "distance": 33543.8,
-    "moving_time": 5189,
-    "total_elevation_gain": 214.0
-  },
-  {
-    "start_date": "2023-01-21T17:04:25Z",
-    "average_watts": 173.3,
-    "average_speed": 7.701,
-    "distance": 22787.5,
-    "moving_time": 2959,
-    "total_elevation_gain": 233.1
-  },
-  {
-    "start_date": "2023-01-23T12:53:29Z",
-    "average_watts": 153.2,
-    "average_speed": 5.66,
-    "distance": 39936.8,
-    "moving_time": 7056,
-    "total_elevation_gain": 236.3
-  },
-  {
-    "start_date": "2023-01-27T13:27:53Z",
-    "average_watts": 152.0,
-    "average_speed": 7.844,
-    "distance": 35166.3,
-    "moving_time": 4483,
-    "total_elevation_gain": 254.9
-  },
-  {
-    "start_date": "2023-01-28T19:51:08Z",
-    "average_watts": 178.2,
-    "average_speed": 3.295,
-    "distance": 5805.9,
-    "moving_time": 1762,
-    "total_elevation_gain": 45.3
-  },
-  {
-    "start_date": "2023-01-30T10:52:40Z",
-    "average_watts": 158.1,
-    "average_speed": 3.35,
-    "distance": 6647.0,
-    "moving_time": 1984,
-    "total_elevation_gain": 89.8
-  },
-  {
-    "start_date": "2023-01-31T14:15:55Z",
-    "average_watts": 146.7,
-    "average_speed": 9.658,
-    "distance": 16621.5,
-    "moving_time": 1721,
-    "total_elevation_gain": 130.8
-  },
-  {
-    "start_date": "2023-02-01T14:28:41Z",
-    "average_watts": 173.1,
-    "average_speed": 5.208,
-    "distance": 68525.0,
-    "moving_time": 13158,
-    "total_elevation_gain": 988.3
-  },
-  {
-    "start_date": "2023-02-02T06:43:55Z",
-    "average_watts": 162.5,
-    "average_speed": 5.889,
-    "distance": 3315.6,
-    "moving_time": 563,
-    "total_elevation_gain": 27.9
-  },
-  {
-    "start_date": "2023-02-04T15:13:36Z",
-    "average_watts": 158.4,
-    "average_speed": 7.359,
-    "distance": 32990.6,
-    "moving_time": 4483,
-    "total_elevation_gain": 415.1
-  },
-  {
-    "start_date": "2023-02-05T18:25:56Z",
-    "average_watts": 162.8,
-    "average_speed": 7.323,
-    "distance": 24787.6,
-    "moving_time": 3385,
-    "total_elevation_gain": 174.3
-  },
-  {
-    "start_date": "2023-02-06T14:46:02Z",
-    "average_watts": 181.7,
-    "average_speed": 6.999,
-    "distance": 51731.0,
-    "moving_time": 7391,
-    "total_elevation_gain": 574.7
-  },
-  {
-    "start_date": "2023-02-08T14:09:46Z",
-    "average_watts": 149.0,
-    "average_speed": 5.288,
-    "distance": 83041.4,
-    "moving_time": 15704,
-    "total_elevation_gain": 571.7
-  },
-  {
-    "start_date": "2023-02-09T17:28:11Z",
-    "average_watts": 157.4,
-    "average_speed": 6.828,
-    "distance": 70183.8,
-    "moving_time": 10279,
-    "total_elevation_gain": 779.6
-  },
-  {
-    "start_date": "2023-02-10T17:46:36Z",
-    "average_watts": 153.1,
-    "average_speed": 5.152,
-    "distance": 69160.9,
-    "moving_time": 13423,
-    "total_elevation_gain": 975.0
-  },
-  {
-    "start_date": "2023-02-11T16:58:16Z",
-    "average_watts": 172.2,
-    "average_speed": 4.312,
-    "distance": 5489.2,
-    "moving_time": 1273,
-    "total_elevation_gain": 39.8
-  },
-  {
-    "start_date": "2023-02-12T06:03:58Z",
-    "average_watts": 164.9,
-    "average_speed": 5.603,
-    "distance": 7821.2,
-    "moving_time": 1396,
-    "total_elevation_gain": 80.5
-  },
-  {
-    "start_date": "2023-02-15T18:26:47Z",
-    "average_watts": 157.2,
-    "average_speed": 5.764,
-    "distance": 6536.1,
-    "moving_time": 1134,
-    "total_elevation_gain": 52.3
-  },
-  {
-    "start_date": "2023-02-18T14:20:51Z",
+    "start_date": "2020-05-12T14:38:14Z",
     "average_watts": 147.3,
-    "average_speed": 5.402,
-    "distance": 5261.6,
-    "moving_time": 974,
-    "total_elevation_gain": 64.6
+    "average_speed": 7.108,
+    "distance": 20394.2,
+    "moving_time": 2869,
+    "total_elevation_gain": 192.1,
+    "type": "Ride"
   },
   {
-    "start_date": "2023-02-20T11:03:46Z",
-    "average_watts": 183.9,
-    "average_speed": 5.137,
-    "distance": 39697.6,
-    "moving_time": 7728,
-    "total_elevation_gain": 252.7
-  },
-  {
-    "start_date": "2023-02-27T13:28:40Z",
-    "average_watts": 144.9,
-    "average_speed": 5.686,
-    "distance": 53113.5,
-    "moving_time": 9341,
-    "total_elevation_gain": 711.3
-  },
-  {
-    "start_date": "2023-03-03T06:37:05Z",
-    "average_watts": 168.0,
-    "average_speed": 7.051,
-    "distance": 34077.2,
-    "moving_time": 4833,
-    "total_elevation_gain": 265.3
-  },
-  {
-    "start_date": "2023-03-06T18:46:44Z",
-    "average_watts": 178.4,
-    "average_speed": 7.102,
-    "distance": 33988.3,
-    "moving_time": 4786,
-    "total_elevation_gain": 409.8
-  },
-  {
-    "start_date": "2023-03-09T09:39:31Z",
-    "average_watts": 181.6,
-    "average_speed": 6.925,
-    "distance": 89612.5,
-    "moving_time": 12940,
-    "total_elevation_gain": 502.1
-  },
-  {
-    "start_date": "2023-03-11T12:40:47Z",
-    "average_watts": 173.3,
-    "average_speed": 7.063,
-    "distance": 10460.7,
-    "moving_time": 1481,
-    "total_elevation_gain": 87.9
-  },
-  {
-    "start_date": "2023-03-12T13:00:31Z",
-    "average_watts": 177.3,
-    "average_speed": 7.863,
-    "distance": 23958.8,
-    "moving_time": 3047,
-    "total_elevation_gain": 343.7
-  },
-  {
-    "start_date": "2023-03-17T18:09:33Z",
-    "average_watts": 152.1,
-    "average_speed": 5.267,
-    "distance": 25464.7,
-    "moving_time": 4835,
-    "total_elevation_gain": 334.9
-  },
-  {
-    "start_date": "2023-03-18T18:05:02Z",
-    "average_watts": 151.6,
-    "average_speed": 5.426,
-    "distance": 21173.3,
-    "moving_time": 3902,
-    "total_elevation_gain": 266.6
-  },
-  {
-    "start_date": "2023-03-19T13:19:29Z",
-    "average_watts": 161.6,
-    "average_speed": 3.189,
-    "distance": 5000.6,
-    "moving_time": 1568,
-    "total_elevation_gain": 73.9
-  },
-  {
-    "start_date": "2023-03-21T09:47:07Z",
-    "average_watts": 148.9,
-    "average_speed": 5.138,
-    "distance": 51596.4,
-    "moving_time": 10042,
-    "total_elevation_gain": 568.2
-  },
-  {
-    "start_date": "2023-03-22T06:52:25Z",
-    "average_watts": 168.4,
-    "average_speed": 5.238,
-    "distance": 31789.9,
-    "moving_time": 6069,
-    "total_elevation_gain": 358.2
-  },
-  {
-    "start_date": "2023-03-23T13:08:46Z",
-    "average_watts": 173.2,
-    "average_speed": 6.374,
-    "distance": 90019.7,
-    "moving_time": 14124,
-    "total_elevation_gain": 534.7
-  },
-  {
-    "start_date": "2023-03-27T10:00:46Z",
-    "average_watts": 177.0,
-    "average_speed": 6.058,
-    "distance": 20039.2,
-    "moving_time": 3308,
-    "total_elevation_gain": 256.5
-  },
-  {
-    "start_date": "2023-03-28T13:14:38Z",
-    "average_watts": 176.5,
-    "average_speed": 7.029,
-    "distance": 37274.0,
-    "moving_time": 5303,
-    "total_elevation_gain": 341.0
-  },
-  {
-    "start_date": "2023-04-03T07:46:43Z",
-    "average_watts": 161.1,
-    "average_speed": 4.699,
-    "distance": 3637.0,
-    "moving_time": 774,
-    "total_elevation_gain": 29.5
-  },
-  {
-    "start_date": "2023-04-04T07:49:12Z",
-    "average_watts": 177.0,
-    "average_speed": 7.645,
-    "distance": 11941.8,
-    "moving_time": 1562,
-    "total_elevation_gain": 107.2
-  },
-  {
-    "start_date": "2023-04-05T10:59:29Z",
-    "average_watts": 182.8,
-    "average_speed": 6.67,
-    "distance": 61341.6,
-    "moving_time": 9197,
-    "total_elevation_gain": 667.4
-  },
-  {
-    "start_date": "2023-04-10T09:47:46Z",
-    "average_watts": 180.1,
-    "average_speed": 5.892,
-    "distance": 62191.8,
-    "moving_time": 10556,
-    "total_elevation_gain": 814.5
-  },
-  {
-    "start_date": "2023-04-12T12:08:06Z",
-    "average_watts": 154.2,
-    "average_speed": 7.204,
-    "distance": 12116.4,
-    "moving_time": 1682,
-    "total_elevation_gain": 138.9
-  },
-  {
-    "start_date": "2023-04-14T09:59:28Z",
-    "average_watts": 178.0,
-    "average_speed": 6.552,
-    "distance": 67488.2,
-    "moving_time": 10300,
-    "total_elevation_gain": 596.1
-  },
-  {
-    "start_date": "2023-04-20T11:39:45Z",
-    "average_watts": 170.3,
-    "average_speed": 9.66,
-    "distance": 20237.4,
-    "moving_time": 2095,
-    "total_elevation_gain": 234.9
-  },
-  {
-    "start_date": "2023-04-21T06:52:45Z",
-    "average_watts": 145.2,
-    "average_speed": 5.336,
-    "distance": 5858.9,
-    "moving_time": 1098,
-    "total_elevation_gain": 58.8
-  },
-  {
-    "start_date": "2023-04-22T19:16:28Z",
-    "average_watts": 162.7,
-    "average_speed": 9.834,
-    "distance": 20907.0,
-    "moving_time": 2126,
-    "total_elevation_gain": 259.7
-  },
-  {
-    "start_date": "2023-04-26T07:45:10Z",
-    "average_watts": 159.9,
-    "average_speed": 6.66,
-    "distance": 65802.5,
-    "moving_time": 9881,
-    "total_elevation_gain": 609.4
-  },
-  {
-    "start_date": "2023-04-30T13:40:37Z",
-    "average_watts": 182.2,
-    "average_speed": 7.281,
-    "distance": 27427.2,
-    "moving_time": 3767,
-    "total_elevation_gain": 263.7
-  },
-  {
-    "start_date": "2023-05-02T14:14:18Z",
-    "average_watts": 181.8,
-    "average_speed": 4.955,
-    "distance": 3225.8,
-    "moving_time": 651,
-    "total_elevation_gain": 47.9
-  },
-  {
-    "start_date": "2023-05-03T10:19:37Z",
-    "average_watts": 166.3,
-    "average_speed": 7.514,
-    "distance": 20649.6,
-    "moving_time": 2748,
-    "total_elevation_gain": 205.8
-  },
-  {
-    "start_date": "2023-05-06T13:56:51Z",
-    "average_watts": 181.0,
-    "average_speed": 8.914,
-    "distance": 11650.1,
-    "moving_time": 1307,
-    "total_elevation_gain": 166.9
-  },
-  {
-    "start_date": "2023-05-09T13:44:30Z",
-    "average_watts": 145.7,
-    "average_speed": 5.735,
-    "distance": 97766.3,
-    "moving_time": 17048,
-    "total_elevation_gain": 667.1
-  },
-  {
-    "start_date": "2023-05-11T16:23:12Z",
-    "average_watts": 168.0,
-    "average_speed": 7.811,
-    "distance": 27136.1,
-    "moving_time": 3474,
-    "total_elevation_gain": 268.8
-  },
-  {
-    "start_date": "2023-05-12T16:09:13Z",
-    "average_watts": 156.4,
-    "average_speed": 5.431,
-    "distance": 69640.6,
-    "moving_time": 12822,
-    "total_elevation_gain": 375.6
-  },
-  {
-    "start_date": "2023-05-14T11:53:38Z",
-    "average_watts": 149.5,
-    "average_speed": 5.615,
-    "distance": 23093.5,
-    "moving_time": 4113,
-    "total_elevation_gain": 264.1
-  },
-  {
-    "start_date": "2023-05-16T18:28:30Z",
-    "average_watts": 154.0,
-    "average_speed": 3.067,
-    "distance": 6026.5,
-    "moving_time": 1965,
-    "total_elevation_gain": 55.4
-  },
-  {
-    "start_date": "2023-05-18T18:36:06Z",
-    "average_watts": 183.1,
-    "average_speed": 6.467,
-    "distance": 38128.5,
-    "moving_time": 5896,
-    "total_elevation_gain": 364.7
-  },
-  {
-    "start_date": "2023-05-19T19:23:46Z",
-    "average_watts": 160.3,
-    "average_speed": 5.915,
-    "distance": 34664.1,
-    "moving_time": 5860,
-    "total_elevation_gain": 230.2
-  },
-  {
-    "start_date": "2023-05-21T08:58:14Z",
-    "average_watts": 159.6,
-    "average_speed": 5.594,
-    "distance": 75363.1,
-    "moving_time": 13472,
-    "total_elevation_gain": 1068.0
-  },
-  {
-    "start_date": "2023-05-22T17:19:41Z",
-    "average_watts": 175.0,
-    "average_speed": 6.665,
-    "distance": 28733.8,
-    "moving_time": 4311,
-    "total_elevation_gain": 344.2
-  },
-  {
-    "start_date": "2023-05-24T10:05:32Z",
-    "average_watts": 152.9,
-    "average_speed": 5.364,
-    "distance": 92976.3,
-    "moving_time": 17334,
-    "total_elevation_gain": 1239.9
-  },
-  {
-    "start_date": "2023-05-27T14:14:11Z",
-    "average_watts": 157.3,
-    "average_speed": 5.794,
-    "distance": 6656.8,
-    "moving_time": 1149,
-    "total_elevation_gain": 76.5
-  },
-  {
-    "start_date": "2023-05-31T07:07:02Z",
-    "average_watts": 162.6,
-    "average_speed": 7.12,
-    "distance": 18925.4,
-    "moving_time": 2658,
-    "total_elevation_gain": 97.7
-  },
-  {
-    "start_date": "2023-06-01T19:56:45Z",
-    "average_watts": 153.5,
-    "average_speed": 7.185,
-    "distance": 24796.8,
-    "moving_time": 3451,
-    "total_elevation_gain": 213.5
-  },
-  {
-    "start_date": "2023-06-02T08:46:05Z",
-    "average_watts": 175.1,
-    "average_speed": 8.294,
-    "distance": 14157.7,
-    "moving_time": 1707,
-    "total_elevation_gain": 127.8
-  },
-  {
-    "start_date": "2023-06-03T18:26:40Z",
-    "average_watts": 176.8,
-    "average_speed": 5.453,
-    "distance": 22999.3,
-    "moving_time": 4218,
-    "total_elevation_gain": 160.9
-  },
-  {
-    "start_date": "2023-06-05T06:31:24Z",
-    "average_watts": 179.4,
-    "average_speed": 6.063,
-    "distance": 79608.9,
-    "moving_time": 13130,
-    "total_elevation_gain": 880.4
-  },
-  {
-    "start_date": "2023-06-06T12:51:32Z",
-    "average_watts": 163.8,
-    "average_speed": 3.167,
-    "distance": 7036.6,
-    "moving_time": 2222,
-    "total_elevation_gain": 51.2
-  },
-  {
-    "start_date": "2023-06-10T14:44:17Z",
-    "average_watts": 167.0,
-    "average_speed": 9.186,
-    "distance": 19842.1,
-    "moving_time": 2160,
-    "total_elevation_gain": 271.9
-  },
-  {
-    "start_date": "2023-06-12T18:30:10Z",
-    "average_watts": 171.7,
-    "average_speed": 6.189,
-    "distance": 52738.5,
-    "moving_time": 8521,
-    "total_elevation_gain": 354.0
-  },
-  {
-    "start_date": "2023-06-14T08:03:11Z",
-    "average_watts": 154.3,
-    "average_speed": 9.695,
-    "distance": 13941.2,
-    "moving_time": 1438,
-    "total_elevation_gain": 104.0
-  },
-  {
-    "start_date": "2023-06-18T08:43:28Z",
-    "average_watts": 148.7,
-    "average_speed": 6.938,
-    "distance": 86331.4,
-    "moving_time": 12443,
-    "total_elevation_gain": 1283.0
-  },
-  {
-    "start_date": "2023-06-19T12:07:10Z",
-    "average_watts": 182.5,
-    "average_speed": 5.164,
-    "distance": 6486.4,
-    "moving_time": 1256,
-    "total_elevation_gain": 69.9
-  },
-  {
-    "start_date": "2023-06-20T08:17:17Z",
-    "average_watts": 150.9,
-    "average_speed": 5.585,
-    "distance": 90337.8,
-    "moving_time": 16176,
-    "total_elevation_gain": 1174.9
-  },
-  {
-    "start_date": "2023-06-21T12:41:15Z",
-    "average_watts": 160.2,
-    "average_speed": 6.873,
-    "distance": 28048.3,
-    "moving_time": 4081,
-    "total_elevation_gain": 165.3
-  },
-  {
-    "start_date": "2023-06-23T17:35:24Z",
-    "average_watts": 181.5,
-    "average_speed": 6.286,
-    "distance": 35583.6,
-    "moving_time": 5661,
-    "total_elevation_gain": 475.6
-  },
-  {
-    "start_date": "2023-06-25T17:00:22Z",
-    "average_watts": 156.9,
-    "average_speed": 8.954,
-    "distance": 20181.9,
-    "moving_time": 2254,
-    "total_elevation_gain": 292.4
-  },
-  {
-    "start_date": "2023-06-26T06:12:01Z",
-    "average_watts": 149.8,
-    "average_speed": 7.247,
-    "distance": 19472.2,
-    "moving_time": 2687,
-    "total_elevation_gain": 224.1
-  },
-  {
-    "start_date": "2023-06-28T14:10:51Z",
-    "average_watts": 148.3,
-    "average_speed": 6.504,
-    "distance": 23057.2,
-    "moving_time": 3545,
-    "total_elevation_gain": 310.4
-  },
-  {
-    "start_date": "2023-07-01T11:20:36Z",
-    "average_watts": 169.9,
-    "average_speed": 3.555,
-    "distance": 6686.4,
-    "moving_time": 1881,
-    "total_elevation_gain": 87.7
-  },
-  {
-    "start_date": "2023-07-05T16:17:11Z",
-    "average_watts": 151.2,
-    "average_speed": 5.558,
-    "distance": 34135.8,
-    "moving_time": 6142,
-    "total_elevation_gain": 310.3
-  },
-  {
-    "start_date": "2023-07-06T18:34:48Z",
-    "average_watts": 162.1,
-    "average_speed": 8.654,
-    "distance": 18537.5,
-    "moving_time": 2142,
-    "total_elevation_gain": 207.1
-  },
-  {
-    "start_date": "2023-07-09T19:40:33Z",
-    "average_watts": 169.7,
-    "average_speed": 8.148,
-    "distance": 10608.8,
-    "moving_time": 1302,
-    "total_elevation_gain": 67.5
-  },
-  {
-    "start_date": "2023-07-10T17:50:58Z",
-    "average_watts": 156.4,
-    "average_speed": 5.127,
-    "distance": 82065.2,
-    "moving_time": 16008,
-    "total_elevation_gain": 983.4
-  },
-  {
-    "start_date": "2023-07-12T18:55:16Z",
-    "average_watts": 167.0,
-    "average_speed": 7.664,
-    "distance": 26747.2,
-    "moving_time": 3490,
-    "total_elevation_gain": 284.2
-  },
-  {
-    "start_date": "2023-07-14T07:35:09Z",
-    "average_watts": 148.2,
-    "average_speed": 6.532,
-    "distance": 53285.4,
-    "moving_time": 8158,
-    "total_elevation_gain": 552.4
-  },
-  {
-    "start_date": "2023-07-15T17:40:04Z",
-    "average_watts": 185.6,
-    "average_speed": 5.618,
-    "distance": 94658.0,
-    "moving_time": 16848,
-    "total_elevation_gain": 483.7
-  },
-  {
-    "start_date": "2023-07-16T07:56:04Z",
-    "average_watts": 184.5,
-    "average_speed": 5.929,
-    "distance": 6509.5,
-    "moving_time": 1098,
-    "total_elevation_gain": 46.7
-  },
-  {
-    "start_date": "2023-07-17T07:16:17Z",
-    "average_watts": 167.7,
-    "average_speed": 6.535,
-    "distance": 87849.3,
-    "moving_time": 13442,
-    "total_elevation_gain": 778.5
-  },
-  {
-    "start_date": "2023-07-18T10:25:56Z",
-    "average_watts": 162.3,
-    "average_speed": 5.608,
-    "distance": 5809.6,
-    "moving_time": 1036,
-    "total_elevation_gain": 35.6
-  },
-  {
-    "start_date": "2023-07-21T09:38:10Z",
-    "average_watts": 152.5,
-    "average_speed": 3.197,
-    "distance": 5821.1,
-    "moving_time": 1821,
-    "total_elevation_gain": 78.1
-  },
-  {
-    "start_date": "2023-07-22T16:47:31Z",
-    "average_watts": 150.3,
-    "average_speed": 6.481,
-    "distance": 79949.7,
-    "moving_time": 12336,
-    "total_elevation_gain": 869.9
-  },
-  {
-    "start_date": "2023-07-23T09:53:44Z",
-    "average_watts": 152.2,
-    "average_speed": 5.899,
-    "distance": 24010.5,
-    "moving_time": 4070,
-    "total_elevation_gain": 218.1
-  },
-  {
-    "start_date": "2023-07-24T06:06:15Z",
-    "average_watts": 153.5,
-    "average_speed": 6.764,
-    "distance": 53901.5,
-    "moving_time": 7969,
-    "total_elevation_gain": 501.1
-  },
-  {
-    "start_date": "2023-07-30T19:09:19Z",
-    "average_watts": 154.1,
-    "average_speed": 5.983,
-    "distance": 53623.9,
-    "moving_time": 8963,
-    "total_elevation_gain": 624.3
-  },
-  {
-    "start_date": "2023-08-01T15:36:09Z",
-    "average_watts": 182.0,
-    "average_speed": 5.527,
-    "distance": 5709.5,
-    "moving_time": 1033,
-    "total_elevation_gain": 76.3
-  },
-  {
-    "start_date": "2023-08-02T18:06:34Z",
-    "average_watts": 178.9,
-    "average_speed": 5.005,
-    "distance": 5415.3,
-    "moving_time": 1082,
-    "total_elevation_gain": 79.4
-  },
-  {
-    "start_date": "2023-08-04T19:21:24Z",
+    "start_date": "2020-05-14T07:37:07Z",
     "average_watts": 154.5,
-    "average_speed": 6.151,
-    "distance": 74376.5,
-    "moving_time": 12092,
-    "total_elevation_gain": 632.7
-  },
-  {
-    "start_date": "2023-08-07T11:30:53Z",
-    "average_watts": 147.7,
-    "average_speed": 5.828,
-    "distance": 5303.6,
-    "moving_time": 910,
-    "total_elevation_gain": 39.4
-  },
-  {
-    "start_date": "2023-08-08T18:44:26Z",
-    "average_watts": 180.4,
-    "average_speed": 5.443,
-    "distance": 34153.3,
-    "moving_time": 6275,
-    "total_elevation_gain": 387.4
-  },
-  {
-    "start_date": "2023-08-10T12:51:46Z",
-    "average_watts": 150.7,
-    "average_speed": 9.865,
-    "distance": 10496.8,
-    "moving_time": 1064,
-    "total_elevation_gain": 115.3
-  },
-  {
-    "start_date": "2023-08-15T06:02:45Z",
-    "average_watts": 178.3,
-    "average_speed": 9.075,
-    "distance": 20464.3,
-    "moving_time": 2255,
-    "total_elevation_gain": 144.8
-  },
-  {
-    "start_date": "2023-08-16T13:35:19Z",
-    "average_watts": 151.2,
-    "average_speed": 9.521,
-    "distance": 21831.0,
-    "moving_time": 2293,
-    "total_elevation_gain": 306.7
-  },
-  {
-    "start_date": "2023-08-17T16:55:37Z",
-    "average_watts": 158.7,
-    "average_speed": 7.147,
-    "distance": 36886.5,
-    "moving_time": 5161,
-    "total_elevation_gain": 536.3
-  },
-  {
-    "start_date": "2023-08-18T11:34:00Z",
-    "average_watts": 174.6,
-    "average_speed": 5.14,
-    "distance": 24672.5,
-    "moving_time": 4800,
-    "total_elevation_gain": 147.3
-  },
-  {
-    "start_date": "2023-08-21T19:30:04Z",
-    "average_watts": 173.3,
-    "average_speed": 8.257,
-    "distance": 15614.5,
-    "moving_time": 1891,
-    "total_elevation_gain": 164.7
-  },
-  {
-    "start_date": "2023-08-22T16:42:35Z",
-    "average_watts": 169.4,
-    "average_speed": 7.004,
-    "distance": 21843.9,
-    "moving_time": 3119,
-    "total_elevation_gain": 268.3
-  },
-  {
-    "start_date": "2023-08-23T06:35:04Z",
-    "average_watts": 159.3,
-    "average_speed": 7.836,
-    "distance": 34798.6,
-    "moving_time": 4441,
-    "total_elevation_gain": 188.0
-  },
-  {
-    "start_date": "2023-08-25T11:49:33Z",
-    "average_watts": 183.8,
-    "average_speed": 3.148,
-    "distance": 3390.7,
-    "moving_time": 1077,
-    "total_elevation_gain": 48.2
-  },
-  {
-    "start_date": "2023-08-26T15:00:58Z",
-    "average_watts": 161.5,
-    "average_speed": 4.426,
-    "distance": 6838.5,
-    "moving_time": 1545,
-    "total_elevation_gain": 64.5
-  },
-  {
-    "start_date": "2023-08-28T08:05:58Z",
-    "average_watts": 156.8,
-    "average_speed": 7.496,
-    "distance": 21632.8,
-    "moving_time": 2886,
-    "total_elevation_gain": 200.3
-  },
-  {
-    "start_date": "2023-08-30T08:00:57Z",
-    "average_watts": 173.1,
-    "average_speed": 9.74,
-    "distance": 15388.9,
-    "moving_time": 1580,
-    "total_elevation_gain": 130.1
-  },
-  {
-    "start_date": "2023-09-01T06:25:31Z",
-    "average_watts": 174.7,
-    "average_speed": 4.956,
-    "distance": 4782.3,
-    "moving_time": 965,
-    "total_elevation_gain": 61.1
-  },
-  {
-    "start_date": "2023-09-04T18:15:09Z",
-    "average_watts": 167.4,
-    "average_speed": 5.312,
-    "distance": 99742.4,
-    "moving_time": 18776,
-    "total_elevation_gain": 646.8
-  },
-  {
-    "start_date": "2023-09-05T16:20:21Z",
-    "average_watts": 162.3,
-    "average_speed": 5.97,
-    "distance": 34240.5,
-    "moving_time": 5735,
-    "total_elevation_gain": 473.5
-  },
-  {
-    "start_date": "2023-09-07T18:43:48Z",
-    "average_watts": 163.8,
-    "average_speed": 5.061,
-    "distance": 23955.1,
-    "moving_time": 4733,
-    "total_elevation_gain": 225.4
-  },
-  {
-    "start_date": "2023-09-09T12:10:30Z",
-    "average_watts": 164.6,
-    "average_speed": 3.17,
-    "distance": 7081.1,
-    "moving_time": 2234,
-    "total_elevation_gain": 75.0
-  },
-  {
-    "start_date": "2023-09-11T13:48:06Z",
-    "average_watts": 174.7,
-    "average_speed": 5.338,
-    "distance": 80531.4,
-    "moving_time": 15086,
-    "total_elevation_gain": 547.3
-  },
-  {
-    "start_date": "2023-09-12T08:17:36Z",
-    "average_watts": 181.0,
-    "average_speed": 7.494,
-    "distance": 13085.1,
-    "moving_time": 1746,
-    "total_elevation_gain": 130.6
-  },
-  {
-    "start_date": "2023-09-14T06:13:20Z",
-    "average_watts": 166.3,
-    "average_speed": 8.026,
-    "distance": 19759.4,
-    "moving_time": 2462,
-    "total_elevation_gain": 244.2
-  },
-  {
-    "start_date": "2023-09-16T11:24:27Z",
-    "average_watts": 159.6,
-    "average_speed": 6.817,
-    "distance": 25913.0,
-    "moving_time": 3801,
-    "total_elevation_gain": 385.8
-  },
-  {
-    "start_date": "2023-09-17T11:37:21Z",
-    "average_watts": 179.4,
-    "average_speed": 3.541,
-    "distance": 3615.4,
-    "moving_time": 1021,
-    "total_elevation_gain": 32.5
-  },
-  {
-    "start_date": "2023-09-21T10:47:06Z",
-    "average_watts": 165.3,
-    "average_speed": 4.949,
-    "distance": 6844.7,
-    "moving_time": 1383,
-    "total_elevation_gain": 34.8
-  },
-  {
-    "start_date": "2023-09-22T12:40:47Z",
-    "average_watts": 166.9,
-    "average_speed": 6.496,
-    "distance": 22858.7,
-    "moving_time": 3519,
-    "total_elevation_gain": 187.2
-  },
-  {
-    "start_date": "2023-09-23T13:15:12Z",
-    "average_watts": 154.1,
-    "average_speed": 4.584,
-    "distance": 4144.3,
-    "moving_time": 904,
-    "total_elevation_gain": 47.0
-  },
-  {
-    "start_date": "2023-09-27T14:43:04Z",
-    "average_watts": 149.0,
-    "average_speed": 7.093,
-    "distance": 21817.9,
-    "moving_time": 3076,
-    "total_elevation_gain": 160.3
-  },
-  {
-    "start_date": "2023-10-01T18:33:13Z",
-    "average_watts": 177.6,
-    "average_speed": 9.747,
-    "distance": 15693.5,
-    "moving_time": 1610,
-    "total_elevation_gain": 111.7
-  },
-  {
-    "start_date": "2023-10-03T12:06:47Z",
-    "average_watts": 163.9,
-    "average_speed": 7.232,
-    "distance": 37373.1,
-    "moving_time": 5168,
-    "total_elevation_gain": 239.2
-  },
-  {
-    "start_date": "2023-10-05T06:15:42Z",
-    "average_watts": 186.0,
-    "average_speed": 7.75,
-    "distance": 39571.2,
-    "moving_time": 5106,
-    "total_elevation_gain": 410.0
-  },
-  {
-    "start_date": "2023-10-08T15:01:34Z",
-    "average_watts": 151.1,
-    "average_speed": 5.765,
-    "distance": 62415.6,
-    "moving_time": 10826,
-    "total_elevation_gain": 501.6
-  },
-  {
-    "start_date": "2023-10-09T08:44:18Z",
-    "average_watts": 174.5,
-    "average_speed": 6.027,
-    "distance": 34386.8,
-    "moving_time": 5705,
-    "total_elevation_gain": 283.6
-  },
-  {
-    "start_date": "2023-10-14T15:01:57Z",
-    "average_watts": 164.7,
-    "average_speed": 9.094,
-    "distance": 17197.3,
-    "moving_time": 1891,
-    "total_elevation_gain": 92.3
-  },
-  {
-    "start_date": "2023-10-17T18:05:08Z",
-    "average_watts": 162.4,
-    "average_speed": 7.538,
-    "distance": 32798.7,
-    "moving_time": 4351,
-    "total_elevation_gain": 194.3
-  },
-  {
-    "start_date": "2023-10-18T06:56:46Z",
-    "average_watts": 171.4,
-    "average_speed": 7.816,
-    "distance": 32414.0,
-    "moving_time": 4147,
-    "total_elevation_gain": 482.5
-  },
-  {
-    "start_date": "2023-10-20T17:56:36Z",
-    "average_watts": 181.4,
-    "average_speed": 4.725,
-    "distance": 4970.9,
-    "moving_time": 1052,
-    "total_elevation_gain": 70.2
-  },
-  {
-    "start_date": "2023-10-21T08:05:23Z",
-    "average_watts": 153.7,
-    "average_speed": 5.031,
-    "distance": 4140.4,
-    "moving_time": 823,
-    "total_elevation_gain": 61.0
-  },
-  {
-    "start_date": "2023-10-22T15:53:35Z",
-    "average_watts": 178.9,
-    "average_speed": 8.327,
-    "distance": 14621.5,
-    "moving_time": 1756,
-    "total_elevation_gain": 148.6
-  },
-  {
-    "start_date": "2023-10-24T18:46:24Z",
-    "average_watts": 168.6,
-    "average_speed": 5.097,
-    "distance": 5489.9,
-    "moving_time": 1077,
-    "total_elevation_gain": 35.8
-  },
-  {
-    "start_date": "2023-10-25T09:43:29Z",
-    "average_watts": 184.5,
-    "average_speed": 8.935,
-    "distance": 14305.3,
-    "moving_time": 1601,
-    "total_elevation_gain": 150.1
-  },
-  {
-    "start_date": "2023-10-26T16:53:08Z",
-    "average_watts": 175.7,
-    "average_speed": 5.065,
-    "distance": 4898.3,
-    "moving_time": 967,
-    "total_elevation_gain": 61.3
-  },
-  {
-    "start_date": "2023-10-27T19:58:50Z",
-    "average_watts": 160.2,
-    "average_speed": 3.468,
-    "distance": 4341.9,
-    "moving_time": 1252,
-    "total_elevation_gain": 34.5
-  },
-  {
-    "start_date": "2023-10-28T15:56:02Z",
-    "average_watts": 187.3,
-    "average_speed": 5.086,
-    "distance": 78992.3,
-    "moving_time": 15530,
-    "total_elevation_gain": 418.5
-  },
-  {
-    "start_date": "2023-10-29T14:52:37Z",
-    "average_watts": 168.5,
-    "average_speed": 5.841,
-    "distance": 24285.8,
-    "moving_time": 4158,
-    "total_elevation_gain": 137.0
-  },
-  {
-    "start_date": "2023-10-30T18:49:18Z",
-    "average_watts": 157.1,
-    "average_speed": 5.915,
-    "distance": 76592.1,
-    "moving_time": 12948,
-    "total_elevation_gain": 862.2
-  },
-  {
-    "start_date": "2023-11-02T13:17:26Z",
-    "average_watts": 149.5,
-    "average_speed": 9.354,
-    "distance": 22122.7,
-    "moving_time": 2365,
-    "total_elevation_gain": 136.2
-  },
-  {
-    "start_date": "2023-11-03T14:18:52Z",
-    "average_watts": 159.5,
-    "average_speed": 5.803,
-    "distance": 7148.7,
-    "moving_time": 1232,
-    "total_elevation_gain": 104.2
-  },
-  {
-    "start_date": "2023-11-05T13:35:09Z",
-    "average_watts": 176.3,
-    "average_speed": 3.252,
-    "distance": 5571.1,
-    "moving_time": 1713,
-    "total_elevation_gain": 51.9
-  },
-  {
-    "start_date": "2023-11-06T07:37:20Z",
-    "average_watts": 156.2,
-    "average_speed": 7.115,
-    "distance": 36002.7,
-    "moving_time": 5060,
-    "total_elevation_gain": 369.3
-  },
-  {
-    "start_date": "2023-11-09T18:35:18Z",
-    "average_watts": 152.1,
-    "average_speed": 7.794,
-    "distance": 23708.8,
-    "moving_time": 3042,
-    "total_elevation_gain": 249.7
-  },
-  {
-    "start_date": "2023-11-10T17:29:46Z",
-    "average_watts": 164.9,
-    "average_speed": 6.36,
-    "distance": 32288.2,
-    "moving_time": 5077,
-    "total_elevation_gain": 165.3
-  },
-  {
-    "start_date": "2023-11-11T07:53:41Z",
-    "average_watts": 169.3,
-    "average_speed": 3.658,
-    "distance": 6123.3,
-    "moving_time": 1674,
-    "total_elevation_gain": 56.4
-  },
-  {
-    "start_date": "2023-11-15T12:33:46Z",
-    "average_watts": 148.2,
-    "average_speed": 5.428,
-    "distance": 31522.8,
-    "moving_time": 5807,
-    "total_elevation_gain": 464.1
-  },
-  {
-    "start_date": "2023-11-19T10:17:44Z",
-    "average_watts": 161.3,
-    "average_speed": 8.074,
-    "distance": 15075.1,
-    "moving_time": 1867,
-    "total_elevation_gain": 144.4
-  },
-  {
-    "start_date": "2023-11-20T12:04:11Z",
-    "average_watts": 187.1,
-    "average_speed": 5.457,
-    "distance": 32985.1,
-    "moving_time": 6044,
-    "total_elevation_gain": 288.9
-  },
-  {
-    "start_date": "2023-11-21T11:42:12Z",
-    "average_watts": 151.0,
-    "average_speed": 5.083,
-    "distance": 38215.6,
-    "moving_time": 7518,
-    "total_elevation_gain": 197.3
-  },
-  {
-    "start_date": "2023-11-24T08:17:46Z",
-    "average_watts": 164.5,
-    "average_speed": 6.485,
-    "distance": 99526.3,
-    "moving_time": 15348,
-    "total_elevation_gain": 1217.1
-  },
-  {
-    "start_date": "2023-11-26T07:46:02Z",
-    "average_watts": 157.5,
-    "average_speed": 9.149,
-    "distance": 21409.1,
-    "moving_time": 2340,
-    "total_elevation_gain": 185.8
-  },
-  {
-    "start_date": "2023-11-27T16:43:57Z",
-    "average_watts": 182.8,
-    "average_speed": 5.568,
-    "distance": 95555.5,
-    "moving_time": 17162,
-    "total_elevation_gain": 767.5
-  },
-  {
-    "start_date": "2023-11-28T15:29:39Z",
-    "average_watts": 171.9,
-    "average_speed": 9.739,
-    "distance": 14734.9,
-    "moving_time": 1513,
-    "total_elevation_gain": 206.0
-  },
-  {
-    "start_date": "2023-11-29T06:50:08Z",
-    "average_watts": 156.1,
-    "average_speed": 5.416,
-    "distance": 3325.1,
-    "moving_time": 614,
-    "total_elevation_gain": 42.3
-  },
-  {
-    "start_date": "2023-11-30T14:21:32Z",
-    "average_watts": 149.1,
-    "average_speed": 8.902,
-    "distance": 14609.0,
-    "moving_time": 1641,
-    "total_elevation_gain": 202.1
-  },
-  {
-    "start_date": "2023-12-03T09:14:01Z",
-    "average_watts": 148.2,
-    "average_speed": 8.003,
-    "distance": 17366.5,
-    "moving_time": 2170,
-    "total_elevation_gain": 111.6
-  },
-  {
-    "start_date": "2023-12-05T18:22:07Z",
-    "average_watts": 169.4,
-    "average_speed": 7.589,
-    "distance": 15542.4,
-    "moving_time": 2048,
-    "total_elevation_gain": 153.7
-  },
-  {
-    "start_date": "2023-12-06T17:28:32Z",
-    "average_watts": 161.8,
-    "average_speed": 6.306,
-    "distance": 89735.6,
-    "moving_time": 14230,
-    "total_elevation_gain": 548.1
-  },
-  {
-    "start_date": "2023-12-07T14:09:02Z",
-    "average_watts": 156.1,
-    "average_speed": 7.638,
-    "distance": 19897.4,
-    "moving_time": 2605,
-    "total_elevation_gain": 228.9
-  },
-  {
-    "start_date": "2023-12-08T17:03:15Z",
-    "average_watts": 172.1,
-    "average_speed": 4.719,
-    "distance": 4369.7,
-    "moving_time": 926,
-    "total_elevation_gain": 56.5
-  },
-  {
-    "start_date": "2023-12-16T14:03:21Z",
-    "average_watts": 182.8,
-    "average_speed": 8.316,
-    "distance": 24815.3,
-    "moving_time": 2984,
-    "total_elevation_gain": 290.1
-  },
-  {
-    "start_date": "2023-12-17T06:46:41Z",
-    "average_watts": 156.8,
-    "average_speed": 3.094,
-    "distance": 4328.3,
-    "moving_time": 1399,
-    "total_elevation_gain": 30.1
-  },
-  {
-    "start_date": "2023-12-18T18:22:36Z",
-    "average_watts": 176.7,
-    "average_speed": 5.004,
-    "distance": 21477.6,
-    "moving_time": 4292,
-    "total_elevation_gain": 156.4
-  },
-  {
-    "start_date": "2023-12-20T10:31:46Z",
-    "average_watts": 177.6,
-    "average_speed": 4.704,
-    "distance": 3908.8,
-    "moving_time": 831,
-    "total_elevation_gain": 27.5
-  },
-  {
-    "start_date": "2023-12-21T12:43:49Z",
-    "average_watts": 170.7,
-    "average_speed": 7.802,
-    "distance": 21010.0,
-    "moving_time": 2693,
-    "total_elevation_gain": 236.0
-  },
-  {
-    "start_date": "2023-12-28T11:21:04Z",
-    "average_watts": 162.7,
-    "average_speed": 7.116,
-    "distance": 39065.7,
-    "moving_time": 5490,
-    "total_elevation_gain": 491.5
-  },
-  {
-    "start_date": "2023-12-30T15:26:49Z",
-    "average_watts": 156.2,
-    "average_speed": 5.278,
-    "distance": 66250.7,
-    "moving_time": 12552,
-    "total_elevation_gain": 401.6
-  },
-  {
-    "start_date": "2024-01-01T16:08:58Z",
-    "average_watts": 156.2,
-    "average_speed": 7.288,
-    "distance": 17789.7,
-    "moving_time": 2441,
-    "total_elevation_gain": 118.6
-  },
-  {
-    "start_date": "2024-01-03T10:15:16Z",
-    "average_watts": 170.3,
-    "average_speed": 3.805,
-    "distance": 3923.3,
-    "moving_time": 1031,
-    "total_elevation_gain": 24.7
-  },
-  {
-    "start_date": "2024-01-04T18:50:03Z",
-    "average_watts": 186.6,
-    "average_speed": 7.04,
-    "distance": 25194.6,
-    "moving_time": 3579,
-    "total_elevation_gain": 142.1
-  },
-  {
-    "start_date": "2024-01-06T10:19:27Z",
-    "average_watts": 156.3,
-    "average_speed": 7.471,
-    "distance": 10870.4,
-    "moving_time": 1455,
-    "total_elevation_gain": 95.8
-  },
-  {
-    "start_date": "2024-01-09T17:44:39Z",
-    "average_watts": 176.8,
-    "average_speed": 7.468,
-    "distance": 22673.1,
-    "moving_time": 3036,
-    "total_elevation_gain": 168.8
-  },
-  {
-    "start_date": "2024-01-10T09:28:49Z",
-    "average_watts": 152.3,
-    "average_speed": 6.496,
-    "distance": 61773.1,
-    "moving_time": 9509,
-    "total_elevation_gain": 768.0
-  },
-  {
-    "start_date": "2024-01-11T07:57:26Z",
-    "average_watts": 156.6,
-    "average_speed": 4.168,
-    "distance": 6381.6,
-    "moving_time": 1531,
-    "total_elevation_gain": 36.1
-  },
-  {
-    "start_date": "2024-01-12T18:42:49Z",
-    "average_watts": 181.2,
-    "average_speed": 7.641,
-    "distance": 23504.2,
-    "moving_time": 3076,
-    "total_elevation_gain": 309.6
-  },
-  {
-    "start_date": "2024-01-14T08:48:46Z",
-    "average_watts": 165.5,
-    "average_speed": 6.391,
-    "distance": 64337.9,
-    "moving_time": 10067,
-    "total_elevation_gain": 419.4
-  },
-  {
-    "start_date": "2024-01-15T08:34:26Z",
-    "average_watts": 180.3,
-    "average_speed": 6.221,
-    "distance": 38273.9,
-    "moving_time": 6152,
-    "total_elevation_gain": 236.3
-  },
-  {
-    "start_date": "2024-01-16T07:45:35Z",
-    "average_watts": 152.0,
-    "average_speed": 7.42,
-    "distance": 26926.6,
-    "moving_time": 3629,
-    "total_elevation_gain": 379.0
-  },
-  {
-    "start_date": "2024-01-18T13:42:11Z",
-    "average_watts": 181.8,
-    "average_speed": 6.03,
-    "distance": 92343.2,
-    "moving_time": 15313,
-    "total_elevation_gain": 838.2
-  },
-  {
-    "start_date": "2024-01-19T16:02:55Z",
-    "average_watts": 168.4,
-    "average_speed": 7.173,
-    "distance": 10622.8,
-    "moving_time": 1481,
-    "total_elevation_gain": 155.0
-  },
-  {
-    "start_date": "2024-01-23T08:44:22Z",
-    "average_watts": 186.5,
-    "average_speed": 4.139,
-    "distance": 5840.4,
-    "moving_time": 1411,
-    "total_elevation_gain": 34.6
-  },
-  {
-    "start_date": "2024-01-25T17:22:17Z",
-    "average_watts": 176.5,
-    "average_speed": 7.111,
-    "distance": 22184.9,
-    "moving_time": 3120,
-    "total_elevation_gain": 220.3
-  },
-  {
-    "start_date": "2024-01-27T16:03:23Z",
-    "average_watts": 182.1,
-    "average_speed": 3.19,
-    "distance": 4153.1,
-    "moving_time": 1302,
-    "total_elevation_gain": 57.6
-  },
-  {
-    "start_date": "2024-01-28T07:53:46Z",
-    "average_watts": 170.7,
-    "average_speed": 6.166,
-    "distance": 74981.9,
-    "moving_time": 12161,
-    "total_elevation_gain": 558.6
-  },
-  {
-    "start_date": "2024-02-03T09:39:12Z",
-    "average_watts": 175.1,
-    "average_speed": 9.143,
-    "distance": 11775.9,
-    "moving_time": 1288,
-    "total_elevation_gain": 94.4
-  },
-  {
-    "start_date": "2024-02-05T10:18:46Z",
-    "average_watts": 150.2,
-    "average_speed": 3.018,
-    "distance": 3772.6,
-    "moving_time": 1250,
-    "total_elevation_gain": 42.0
-  },
-  {
-    "start_date": "2024-02-06T17:52:35Z",
-    "average_watts": 179.3,
-    "average_speed": 3.184,
-    "distance": 4419.5,
-    "moving_time": 1388,
-    "total_elevation_gain": 65.8
-  },
-  {
-    "start_date": "2024-02-08T15:31:33Z",
-    "average_watts": 151.7,
-    "average_speed": 7.775,
-    "distance": 22042.8,
-    "moving_time": 2835,
-    "total_elevation_gain": 305.3
-  },
-  {
-    "start_date": "2024-02-13T10:33:45Z",
-    "average_watts": 179.7,
-    "average_speed": 5.966,
-    "distance": 69076.6,
-    "moving_time": 11579,
-    "total_elevation_gain": 424.8
-  },
-  {
-    "start_date": "2024-02-15T18:17:34Z",
-    "average_watts": 160.8,
-    "average_speed": 6.67,
-    "distance": 83781.8,
-    "moving_time": 12561,
-    "total_elevation_gain": 1023.2
-  },
-  {
-    "start_date": "2024-02-16T13:45:33Z",
-    "average_watts": 166.8,
-    "average_speed": 4.635,
-    "distance": 7407.2,
-    "moving_time": 1598,
-    "total_elevation_gain": 90.1
-  },
-  {
-    "start_date": "2024-02-17T10:20:32Z",
-    "average_watts": 168.5,
-    "average_speed": 7.271,
-    "distance": 24839.1,
-    "moving_time": 3416,
-    "total_elevation_gain": 192.1
-  },
-  {
-    "start_date": "2024-02-20T07:47:42Z",
-    "average_watts": 174.2,
-    "average_speed": 8.25,
-    "distance": 11509.2,
-    "moving_time": 1395,
-    "total_elevation_gain": 128.3
-  },
-  {
-    "start_date": "2024-02-21T19:49:04Z",
-    "average_watts": 173.7,
-    "average_speed": 3.691,
-    "distance": 4476.6,
-    "moving_time": 1213,
-    "total_elevation_gain": 30.9
-  },
-  {
-    "start_date": "2024-02-22T06:13:51Z",
-    "average_watts": 160.1,
-    "average_speed": 7.425,
-    "distance": 16527.6,
-    "moving_time": 2226,
-    "total_elevation_gain": 141.4
-  },
-  {
-    "start_date": "2024-02-23T09:54:05Z",
-    "average_watts": 177.2,
-    "average_speed": 8.922,
-    "distance": 18664.6,
-    "moving_time": 2092,
-    "total_elevation_gain": 164.5
-  },
-  {
-    "start_date": "2024-02-24T18:47:12Z",
-    "average_watts": 158.1,
-    "average_speed": 7.568,
-    "distance": 22031.8,
-    "moving_time": 2911,
-    "total_elevation_gain": 245.6
-  },
-  {
-    "start_date": "2024-02-26T10:30:03Z",
-    "average_watts": 167.4,
-    "average_speed": 7.651,
-    "distance": 29791.5,
-    "moving_time": 3894,
-    "total_elevation_gain": 175.7
-  },
-  {
-    "start_date": "2024-02-27T06:41:34Z",
-    "average_watts": 165.3,
-    "average_speed": 5.2,
-    "distance": 75106.0,
-    "moving_time": 14443,
-    "total_elevation_gain": 632.4
-  },
-  {
-    "start_date": "2024-02-28T13:59:53Z",
-    "average_watts": 161.7,
-    "average_speed": 4.074,
-    "distance": 7256.6,
-    "moving_time": 1781,
-    "total_elevation_gain": 84.6
-  },
-  {
-    "start_date": "2024-03-01T10:21:00Z",
-    "average_watts": 162.6,
-    "average_speed": 6.859,
-    "distance": 26022.4,
-    "moving_time": 3794,
-    "total_elevation_gain": 173.4
-  },
-  {
-    "start_date": "2024-03-03T10:35:54Z",
-    "average_watts": 179.2,
-    "average_speed": 6.706,
-    "distance": 76924.2,
-    "moving_time": 11471,
-    "total_elevation_gain": 422.6
-  },
-  {
-    "start_date": "2024-03-04T19:06:35Z",
-    "average_watts": 155.8,
-    "average_speed": 5.482,
-    "distance": 87284.6,
-    "moving_time": 15921,
-    "total_elevation_gain": 583.9
-  },
-  {
-    "start_date": "2024-03-07T18:51:20Z",
+    "average_speed": 7.411,
+    "distance": 38721.8,
+    "moving_time": 5225,
+    "total_elevation_gain": 342.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-19T11:48:19Z",
+    "average_watts": 162.2,
+    "average_speed": 7.336,
+    "distance": 21282.3,
+    "moving_time": 2901,
+    "total_elevation_gain": 308.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-22T18:55:26Z",
     "average_watts": 168.7,
-    "average_speed": 8.028,
-    "distance": 13856.0,
-    "moving_time": 1726,
-    "total_elevation_gain": 147.7
-  },
-  {
-    "start_date": "2024-03-09T07:45:58Z",
-    "average_watts": 182.6,
-    "average_speed": 7.04,
-    "distance": 14087.2,
-    "moving_time": 2001,
-    "total_elevation_gain": 166.6
-  },
-  {
-    "start_date": "2024-03-11T11:06:18Z",
-    "average_watts": 159.9,
-    "average_speed": 9.883,
-    "distance": 22502.7,
-    "moving_time": 2277,
-    "total_elevation_gain": 199.4
-  },
-  {
-    "start_date": "2024-03-14T11:34:39Z",
-    "average_watts": 174.7,
-    "average_speed": 6.687,
-    "distance": 53224.6,
-    "moving_time": 7960,
-    "total_elevation_gain": 734.0
-  },
-  {
-    "start_date": "2024-03-16T18:39:48Z",
-    "average_watts": 162.0,
-    "average_speed": 6.334,
-    "distance": 61690.3,
-    "moving_time": 9739,
-    "total_elevation_gain": 495.2
-  },
-  {
-    "start_date": "2024-03-18T12:03:53Z",
-    "average_watts": 169.9,
-    "average_speed": 7.673,
-    "distance": 29495.8,
-    "moving_time": 3844,
-    "total_elevation_gain": 359.3
-  },
-  {
-    "start_date": "2024-03-19T07:08:45Z",
-    "average_watts": 160.7,
-    "average_speed": 5.615,
-    "distance": 54593.8,
-    "moving_time": 9722,
-    "total_elevation_gain": 722.2
-  },
-  {
-    "start_date": "2024-03-20T13:27:09Z",
-    "average_watts": 158.8,
-    "average_speed": 6.556,
-    "distance": 69123.1,
-    "moving_time": 10544,
-    "total_elevation_gain": 839.9
-  },
-  {
-    "start_date": "2024-03-24T12:01:18Z",
-    "average_watts": 182.0,
-    "average_speed": 8.535,
-    "distance": 16438.5,
-    "moving_time": 1926,
-    "total_elevation_gain": 104.5
-  },
-  {
-    "start_date": "2024-03-28T09:37:09Z",
-    "average_watts": 173.5,
-    "average_speed": 7.134,
-    "distance": 32508.8,
-    "moving_time": 4557,
-    "total_elevation_gain": 349.1
-  },
-  {
-    "start_date": "2024-03-29T06:26:18Z",
-    "average_watts": 152.4,
-    "average_speed": 5.082,
-    "distance": 26010.1,
-    "moving_time": 5118,
-    "total_elevation_gain": 373.9
-  },
-  {
-    "start_date": "2024-03-30T18:07:58Z",
-    "average_watts": 161.9,
-    "average_speed": 4.012,
-    "distance": 4661.8,
-    "moving_time": 1162,
-    "total_elevation_gain": 42.3
-  },
-  {
-    "start_date": "2024-03-31T14:18:21Z",
-    "average_watts": 176.4,
-    "average_speed": 6.712,
-    "distance": 82476.4,
-    "moving_time": 12288,
-    "total_elevation_gain": 1190.2
-  },
-  {
-    "start_date": "2024-04-01T09:09:26Z",
-    "average_watts": 151.0,
-    "average_speed": 4.599,
-    "distance": 3095.0,
-    "moving_time": 673,
-    "total_elevation_gain": 30.9
-  },
-  {
-    "start_date": "2024-04-02T10:42:19Z",
-    "average_watts": 182.9,
-    "average_speed": 6.306,
-    "distance": 52245.7,
-    "moving_time": 8285,
-    "total_elevation_gain": 365.6
-  },
-  {
-    "start_date": "2024-04-06T12:47:28Z",
-    "average_watts": 162.6,
-    "average_speed": 6.812,
-    "distance": 63804.5,
-    "moving_time": 9366,
-    "total_elevation_gain": 741.0
-  },
-  {
-    "start_date": "2024-04-08T13:00:13Z",
-    "average_watts": 184.9,
-    "average_speed": 6.957,
-    "distance": 25937.2,
-    "moving_time": 3728,
-    "total_elevation_gain": 345.5
-  },
-  {
-    "start_date": "2024-04-09T07:02:54Z",
-    "average_watts": 179.6,
-    "average_speed": 5.117,
-    "distance": 6160.3,
-    "moving_time": 1204,
-    "total_elevation_gain": 44.5
-  },
-  {
-    "start_date": "2024-04-12T11:02:13Z",
-    "average_watts": 167.7,
-    "average_speed": 6.035,
-    "distance": 64939.0,
-    "moving_time": 10761,
-    "total_elevation_gain": 685.3
-  },
-  {
-    "start_date": "2024-04-15T11:43:10Z",
-    "average_watts": 171.6,
-    "average_speed": 7.442,
-    "distance": 35957.3,
-    "moving_time": 4832,
-    "total_elevation_gain": 358.9
-  },
-  {
-    "start_date": "2024-04-17T17:22:04Z",
-    "average_watts": 179.2,
-    "average_speed": 9.949,
-    "distance": 11163.3,
-    "moving_time": 1122,
-    "total_elevation_gain": 69.5
-  },
-  {
-    "start_date": "2024-04-18T15:54:49Z",
-    "average_watts": 180.1,
-    "average_speed": 5.062,
-    "distance": 91723.1,
-    "moving_time": 18121,
-    "total_elevation_gain": 1347.9
-  },
-  {
-    "start_date": "2024-04-20T13:22:11Z",
-    "average_watts": 181.6,
-    "average_speed": 6.991,
-    "distance": 65012.1,
-    "moving_time": 9300,
-    "total_elevation_gain": 575.7
-  },
-  {
-    "start_date": "2024-04-21T19:47:26Z",
-    "average_watts": 153.5,
-    "average_speed": 3.271,
-    "distance": 3019.0,
-    "moving_time": 923,
-    "total_elevation_gain": 27.0
-  },
-  {
-    "start_date": "2024-04-22T06:27:06Z",
-    "average_watts": 167.5,
-    "average_speed": 9.257,
-    "distance": 13450.1,
-    "moving_time": 1453,
-    "total_elevation_gain": 172.4
-  },
-  {
-    "start_date": "2024-04-26T17:26:38Z",
-    "average_watts": 165.6,
-    "average_speed": 5.699,
-    "distance": 61111.3,
-    "moving_time": 10723,
-    "total_elevation_gain": 805.0
-  },
-  {
-    "start_date": "2024-04-27T07:08:48Z",
-    "average_watts": 173.7,
-    "average_speed": 6.956,
-    "distance": 35306.3,
-    "moving_time": 5076,
-    "total_elevation_gain": 449.2
-  },
-  {
-    "start_date": "2024-04-30T11:51:29Z",
-    "average_watts": 157.7,
-    "average_speed": 3.671,
-    "distance": 6076.2,
-    "moving_time": 1655,
-    "total_elevation_gain": 37.6
-  },
-  {
-    "start_date": "2024-05-01T10:08:23Z",
-    "average_watts": 158.1,
-    "average_speed": 7.081,
-    "distance": 14063.1,
-    "moving_time": 1986,
-    "total_elevation_gain": 180.4
-  },
-  {
-    "start_date": "2024-05-02T10:15:33Z",
-    "average_watts": 173.5,
-    "average_speed": 4.286,
-    "distance": 6931.0,
-    "moving_time": 1617,
-    "total_elevation_gain": 40.2
-  },
-  {
-    "start_date": "2024-05-03T17:48:03Z",
-    "average_watts": 167.2,
-    "average_speed": 3.361,
-    "distance": 7022.2,
-    "moving_time": 2089,
-    "total_elevation_gain": 51.9
-  },
-  {
-    "start_date": "2024-05-04T13:28:40Z",
-    "average_watts": 178.8,
-    "average_speed": 7.515,
-    "distance": 24002.6,
-    "moving_time": 3194,
-    "total_elevation_gain": 210.9
-  },
-  {
-    "start_date": "2024-05-06T08:25:18Z",
-    "average_watts": 162.1,
-    "average_speed": 5.967,
-    "distance": 37925.0,
-    "moving_time": 6356,
-    "total_elevation_gain": 507.5
-  },
-  {
-    "start_date": "2024-05-07T06:00:11Z",
-    "average_watts": 177.2,
-    "average_speed": 6.266,
-    "distance": 57243.7,
-    "moving_time": 9135,
-    "total_elevation_gain": 603.5
-  },
-  {
-    "start_date": "2024-05-09T15:02:38Z",
-    "average_watts": 185.6,
-    "average_speed": 5.088,
-    "distance": 5545.8,
-    "moving_time": 1090,
-    "total_elevation_gain": 69.0
-  },
-  {
-    "start_date": "2024-05-10T16:44:20Z",
-    "average_watts": 155.1,
-    "average_speed": 5.728,
-    "distance": 94911.9,
-    "moving_time": 16571,
-    "total_elevation_gain": 995.4
-  },
-  {
-    "start_date": "2024-05-11T06:16:43Z",
-    "average_watts": 165.8,
-    "average_speed": 8.486,
-    "distance": 17005.1,
-    "moving_time": 2004,
-    "total_elevation_gain": 192.4
-  },
-  {
-    "start_date": "2024-05-12T08:53:37Z",
-    "average_watts": 153.7,
-    "average_speed": 5.228,
-    "distance": 7799.8,
-    "moving_time": 1492,
-    "total_elevation_gain": 41.2
-  },
-  {
-    "start_date": "2024-05-15T18:13:25Z",
-    "average_watts": 166.1,
-    "average_speed": 7.954,
-    "distance": 15630.4,
-    "moving_time": 1965,
-    "total_elevation_gain": 122.4
-  },
-  {
-    "start_date": "2024-05-18T17:16:32Z",
-    "average_watts": 155.9,
-    "average_speed": 3.802,
-    "distance": 5075.2,
-    "moving_time": 1335,
-    "total_elevation_gain": 33.9
-  },
-  {
-    "start_date": "2024-05-19T14:51:01Z",
-    "average_watts": 160.2,
-    "average_speed": 6.781,
-    "distance": 37851.2,
-    "moving_time": 5582,
-    "total_elevation_gain": 511.3
-  },
-  {
-    "start_date": "2024-05-20T06:35:15Z",
-    "average_watts": 175.5,
-    "average_speed": 5.804,
-    "distance": 65745.8,
-    "moving_time": 11328,
-    "total_elevation_gain": 895.2
-  },
-  {
-    "start_date": "2024-05-22T06:33:18Z",
-    "average_watts": 154.6,
-    "average_speed": 6.512,
-    "distance": 24700.3,
-    "moving_time": 3793,
-    "total_elevation_gain": 290.9
-  },
-  {
-    "start_date": "2024-05-24T13:29:26Z",
-    "average_watts": 156.3,
-    "average_speed": 6.785,
-    "distance": 25577.9,
-    "moving_time": 3770,
-    "total_elevation_gain": 326.5
-  },
-  {
-    "start_date": "2024-05-28T13:54:12Z",
-    "average_watts": 151.2,
-    "average_speed": 4.475,
-    "distance": 3844.4,
-    "moving_time": 859,
-    "total_elevation_gain": 43.6
-  },
-  {
-    "start_date": "2024-05-29T15:37:43Z",
-    "average_watts": 162.4,
-    "average_speed": 3.783,
-    "distance": 6620.5,
-    "moving_time": 1750,
-    "total_elevation_gain": 67.2
-  },
-  {
-    "start_date": "2024-06-01T07:26:45Z",
-    "average_watts": 167.3,
-    "average_speed": 8.545,
-    "distance": 14586.3,
-    "moving_time": 1707,
-    "total_elevation_gain": 185.1
-  },
-  {
-    "start_date": "2024-06-02T11:15:41Z",
-    "average_watts": 175.0,
-    "average_speed": 8.69,
-    "distance": 16710.4,
-    "moving_time": 1923,
-    "total_elevation_gain": 137.6
-  },
-  {
-    "start_date": "2024-06-05T14:19:52Z",
-    "average_watts": 151.2,
-    "average_speed": 5.759,
-    "distance": 20166.4,
-    "moving_time": 3502,
-    "total_elevation_gain": 267.0
-  },
-  {
-    "start_date": "2024-06-06T11:57:34Z",
-    "average_watts": 188.4,
-    "average_speed": 5.075,
-    "distance": 21145.6,
-    "moving_time": 4167,
-    "total_elevation_gain": 295.1
-  },
-  {
-    "start_date": "2024-06-07T19:22:49Z",
-    "average_watts": 174.1,
-    "average_speed": 7.588,
-    "distance": 18765.7,
-    "moving_time": 2473,
-    "total_elevation_gain": 154.1
-  },
-  {
-    "start_date": "2024-06-08T09:44:06Z",
-    "average_watts": 163.7,
-    "average_speed": 5.093,
-    "distance": 74871.3,
-    "moving_time": 14700,
-    "total_elevation_gain": 419.5
-  },
-  {
-    "start_date": "2024-06-11T08:18:41Z",
-    "average_watts": 174.9,
-    "average_speed": 7.228,
-    "distance": 24829.0,
-    "moving_time": 3435,
-    "total_elevation_gain": 297.3
-  },
-  {
-    "start_date": "2024-06-12T16:31:58Z",
-    "average_watts": 186.5,
-    "average_speed": 9.302,
-    "distance": 18575.9,
-    "moving_time": 1997,
-    "total_elevation_gain": 261.4
-  },
-  {
-    "start_date": "2024-06-13T19:43:45Z",
-    "average_watts": 165.6,
-    "average_speed": 5.093,
-    "distance": 71376.8,
-    "moving_time": 14014,
-    "total_elevation_gain": 545.7
-  },
-  {
-    "start_date": "2024-06-16T19:42:32Z",
-    "average_watts": 174.9,
-    "average_speed": 5.289,
-    "distance": 32518.8,
-    "moving_time": 6148,
-    "total_elevation_gain": 486.9
-  },
-  {
-    "start_date": "2024-06-17T13:02:29Z",
-    "average_watts": 165.2,
-    "average_speed": 5.623,
-    "distance": 22509.3,
-    "moving_time": 4003,
-    "total_elevation_gain": 120.6
-  },
-  {
-    "start_date": "2024-06-19T11:59:00Z",
-    "average_watts": 159.3,
-    "average_speed": 7.147,
-    "distance": 22449.3,
-    "moving_time": 3141,
-    "total_elevation_gain": 172.8
-  },
-  {
-    "start_date": "2024-06-20T18:25:33Z",
-    "average_watts": 179.7,
-    "average_speed": 6.047,
-    "distance": 83530.1,
-    "moving_time": 13813,
-    "total_elevation_gain": 1162.7
-  },
-  {
-    "start_date": "2024-06-21T06:24:35Z",
-    "average_watts": 182.4,
-    "average_speed": 8.07,
-    "distance": 24389.0,
-    "moving_time": 3022,
-    "total_elevation_gain": 353.0
-  },
-  {
-    "start_date": "2024-06-22T18:06:42Z",
-    "average_watts": 166.5,
-    "average_speed": 4.026,
-    "distance": 7955.2,
-    "moving_time": 1976,
-    "total_elevation_gain": 90.5
-  },
-  {
-    "start_date": "2024-06-23T11:40:10Z",
-    "average_watts": 187.4,
-    "average_speed": 6.133,
-    "distance": 53384.3,
-    "moving_time": 8705,
-    "total_elevation_gain": 282.3
-  },
-  {
-    "start_date": "2024-06-28T17:11:39Z",
-    "average_watts": 151.9,
-    "average_speed": 5.269,
-    "distance": 3319.8,
-    "moving_time": 630,
-    "total_elevation_gain": 25.3
-  },
-  {
-    "start_date": "2024-06-29T07:59:16Z",
-    "average_watts": 169.4,
-    "average_speed": 6.505,
-    "distance": 32826.1,
-    "moving_time": 5046,
-    "total_elevation_gain": 351.0
-  },
-  {
-    "start_date": "2024-07-01T06:32:41Z",
-    "average_watts": 179.3,
-    "average_speed": 3.254,
-    "distance": 6876.1,
-    "moving_time": 2113,
-    "total_elevation_gain": 77.2
-  },
-  {
-    "start_date": "2024-07-06T09:03:44Z",
-    "average_watts": 170.9,
-    "average_speed": 7.738,
-    "distance": 23601.9,
-    "moving_time": 3050,
-    "total_elevation_gain": 335.9
-  },
-  {
-    "start_date": "2024-07-07T11:41:28Z",
-    "average_watts": 184.7,
-    "average_speed": 4.886,
-    "distance": 6875.0,
-    "moving_time": 1407,
-    "total_elevation_gain": 45.0
-  },
-  {
-    "start_date": "2024-07-10T13:57:28Z",
-    "average_watts": 173.3,
-    "average_speed": 8.676,
-    "distance": 21300.0,
-    "moving_time": 2455,
-    "total_elevation_gain": 257.8
-  },
-  {
-    "start_date": "2024-07-11T14:24:03Z",
-    "average_watts": 179.6,
-    "average_speed": 6.351,
-    "distance": 80059.6,
-    "moving_time": 12605,
-    "total_elevation_gain": 943.7
-  },
-  {
-    "start_date": "2024-07-13T07:19:00Z",
-    "average_watts": 179.1,
-    "average_speed": 4.891,
-    "distance": 4455.5,
-    "moving_time": 911,
-    "total_elevation_gain": 66.7
-  },
-  {
-    "start_date": "2024-07-15T15:03:54Z",
-    "average_watts": 187.8,
-    "average_speed": 4.735,
-    "distance": 6884.9,
-    "moving_time": 1454,
-    "total_elevation_gain": 35.0
-  },
-  {
-    "start_date": "2024-07-17T12:16:19Z",
-    "average_watts": 189.2,
-    "average_speed": 6.191,
-    "distance": 98636.0,
-    "moving_time": 15932,
-    "total_elevation_gain": 1301.1
-  },
-  {
-    "start_date": "2024-07-20T06:53:20Z",
-    "average_watts": 164.2,
-    "average_speed": 8.316,
-    "distance": 20973.6,
-    "moving_time": 2522,
-    "total_elevation_gain": 127.6
-  },
-  {
-    "start_date": "2024-07-22T12:44:13Z",
-    "average_watts": 189.7,
-    "average_speed": 5.035,
-    "distance": 84357.4,
-    "moving_time": 16753,
-    "total_elevation_gain": 966.7
-  },
-  {
-    "start_date": "2024-07-23T09:25:43Z",
-    "average_watts": 155.9,
-    "average_speed": 8.449,
-    "distance": 19964.0,
-    "moving_time": 2363,
-    "total_elevation_gain": 245.9
-  },
-  {
-    "start_date": "2024-07-26T11:31:47Z",
-    "average_watts": 171.7,
-    "average_speed": 7.469,
-    "distance": 38786.2,
-    "moving_time": 5193,
-    "total_elevation_gain": 352.3
-  },
-  {
-    "start_date": "2024-07-30T11:13:22Z",
-    "average_watts": 158.7,
-    "average_speed": 6.941,
-    "distance": 84587.0,
-    "moving_time": 12187,
-    "total_elevation_gain": 933.9
-  },
-  {
-    "start_date": "2024-08-03T12:29:18Z",
-    "average_watts": 156.6,
-    "average_speed": 7.551,
-    "distance": 26246.5,
-    "moving_time": 3476,
-    "total_elevation_gain": 226.0
-  },
-  {
-    "start_date": "2024-08-08T19:48:38Z",
-    "average_watts": 177.2,
-    "average_speed": 7.518,
-    "distance": 15065.4,
-    "moving_time": 2004,
-    "total_elevation_gain": 174.2
-  },
-  {
-    "start_date": "2024-08-09T06:24:13Z",
-    "average_watts": 187.2,
-    "average_speed": 8.138,
-    "distance": 23357.4,
-    "moving_time": 2870,
-    "total_elevation_gain": 343.7
-  },
-  {
-    "start_date": "2024-08-11T17:49:52Z",
-    "average_watts": 164.9,
-    "average_speed": 6.589,
-    "distance": 22607.9,
-    "moving_time": 3431,
-    "total_elevation_gain": 150.9
-  },
-  {
-    "start_date": "2024-08-13T13:53:27Z",
-    "average_watts": 176.4,
-    "average_speed": 6.417,
-    "distance": 56227.2,
-    "moving_time": 8762,
-    "total_elevation_gain": 374.1
-  },
-  {
-    "start_date": "2024-08-14T16:37:11Z",
-    "average_watts": 161.6,
-    "average_speed": 6.038,
-    "distance": 83037.1,
-    "moving_time": 13752,
-    "total_elevation_gain": 605.1
-  },
-  {
-    "start_date": "2024-08-19T08:54:46Z",
-    "average_watts": 159.3,
-    "average_speed": 7.744,
-    "distance": 18942.1,
-    "moving_time": 2446,
-    "total_elevation_gain": 202.5
-  },
-  {
-    "start_date": "2024-08-20T11:45:49Z",
-    "average_watts": 188.5,
-    "average_speed": 6.721,
-    "distance": 79948.0,
-    "moving_time": 11896,
-    "total_elevation_gain": 1046.0
-  },
-  {
-    "start_date": "2024-08-21T14:14:58Z",
-    "average_watts": 156.1,
-    "average_speed": 6.676,
-    "distance": 62216.3,
-    "moving_time": 9320,
-    "total_elevation_gain": 848.5
-  },
-  {
-    "start_date": "2024-08-27T10:13:05Z",
-    "average_watts": 161.3,
-    "average_speed": 5.396,
-    "distance": 50724.4,
-    "moving_time": 9401,
-    "total_elevation_gain": 560.8
-  },
-  {
-    "start_date": "2024-08-28T12:12:39Z",
-    "average_watts": 172.6,
-    "average_speed": 3.561,
-    "distance": 6758.6,
-    "moving_time": 1898,
-    "total_elevation_gain": 79.0
-  },
-  {
-    "start_date": "2024-09-01T09:26:54Z",
-    "average_watts": 153.8,
-    "average_speed": 8.413,
-    "distance": 13713.5,
-    "moving_time": 1630,
-    "total_elevation_gain": 167.7
-  },
-  {
-    "start_date": "2024-09-03T14:14:29Z",
-    "average_watts": 176.0,
-    "average_speed": 5.532,
-    "distance": 39037.4,
-    "moving_time": 7057,
-    "total_elevation_gain": 386.6
-  },
-  {
-    "start_date": "2024-09-05T07:30:34Z",
-    "average_watts": 188.4,
-    "average_speed": 7.228,
-    "distance": 22102.4,
-    "moving_time": 3058,
-    "total_elevation_gain": 115.0
-  },
-  {
-    "start_date": "2024-09-06T13:49:32Z",
-    "average_watts": 174.0,
-    "average_speed": 9.714,
-    "distance": 18562.8,
-    "moving_time": 1911,
-    "total_elevation_gain": 94.9
-  },
-  {
-    "start_date": "2024-09-07T17:18:55Z",
-    "average_watts": 164.2,
-    "average_speed": 5.567,
-    "distance": 37835.7,
-    "moving_time": 6796,
-    "total_elevation_gain": 557.8
-  },
-  {
-    "start_date": "2024-09-08T15:34:47Z",
-    "average_watts": 187.7,
-    "average_speed": 9.705,
-    "distance": 15876.7,
-    "moving_time": 1636,
-    "total_elevation_gain": 95.1
-  },
-  {
-    "start_date": "2024-09-11T11:46:58Z",
-    "average_watts": 179.6,
-    "average_speed": 3.424,
-    "distance": 7192.8,
-    "moving_time": 2101,
-    "total_elevation_gain": 42.5
-  },
-  {
-    "start_date": "2024-09-13T07:40:13Z",
-    "average_watts": 164.7,
-    "average_speed": 7.381,
-    "distance": 10149.0,
-    "moving_time": 1375,
-    "total_elevation_gain": 103.1
-  },
-  {
-    "start_date": "2024-09-14T11:56:52Z",
-    "average_watts": 166.0,
-    "average_speed": 6.93,
-    "distance": 52074.5,
-    "moving_time": 7514,
-    "total_elevation_gain": 755.7
-  },
-  {
-    "start_date": "2024-09-15T17:47:56Z",
-    "average_watts": 189.7,
-    "average_speed": 7.365,
-    "distance": 10164.2,
-    "moving_time": 1380,
-    "total_elevation_gain": 85.2
-  },
-  {
-    "start_date": "2024-09-17T07:07:18Z",
-    "average_watts": 184.2,
-    "average_speed": 3.278,
-    "distance": 7185.5,
-    "moving_time": 2192,
-    "total_elevation_gain": 52.1
-  },
-  {
-    "start_date": "2024-09-18T16:28:48Z",
-    "average_watts": 154.3,
-    "average_speed": 9.928,
-    "distance": 20849.0,
-    "moving_time": 2100,
-    "total_elevation_gain": 231.6
-  },
-  {
-    "start_date": "2024-09-19T09:54:27Z",
-    "average_watts": 189.2,
-    "average_speed": 7.711,
-    "distance": 15862.1,
-    "moving_time": 2057,
-    "total_elevation_gain": 92.9
-  },
-  {
-    "start_date": "2024-09-22T14:20:05Z",
-    "average_watts": 183.8,
-    "average_speed": 5.756,
-    "distance": 74976.4,
-    "moving_time": 13025,
-    "total_elevation_gain": 1057.9
-  },
-  {
-    "start_date": "2024-09-24T11:05:37Z",
-    "average_watts": 183.7,
-    "average_speed": 5.536,
-    "distance": 3144.2,
-    "moving_time": 568,
-    "total_elevation_gain": 34.1
-  },
-  {
-    "start_date": "2024-09-25T11:50:59Z",
-    "average_watts": 181.0,
-    "average_speed": 3.244,
-    "distance": 5466.7,
-    "moving_time": 1685,
-    "total_elevation_gain": 39.5
-  },
-  {
-    "start_date": "2024-09-28T18:46:49Z",
-    "average_watts": 165.6,
-    "average_speed": 9.815,
-    "distance": 10875.1,
-    "moving_time": 1108,
-    "total_elevation_gain": 141.3
-  },
-  {
-    "start_date": "2024-09-30T06:51:17Z",
-    "average_watts": 179.1,
-    "average_speed": 7.494,
-    "distance": 18503.3,
-    "moving_time": 2469,
-    "total_elevation_gain": 236.2
-  },
-  {
-    "start_date": "2024-10-03T15:38:33Z",
-    "average_watts": 164.3,
-    "average_speed": 5.09,
-    "distance": 84765.5,
-    "moving_time": 16654,
-    "total_elevation_gain": 818.9
-  },
-  {
-    "start_date": "2024-10-07T15:40:05Z",
-    "average_watts": 163.5,
-    "average_speed": 3.854,
-    "distance": 6906.4,
-    "moving_time": 1792,
-    "total_elevation_gain": 79.9
-  },
-  {
-    "start_date": "2024-10-09T12:09:53Z",
-    "average_watts": 160.7,
-    "average_speed": 5.833,
-    "distance": 37981.4,
-    "moving_time": 6511,
-    "total_elevation_gain": 554.8
-  },
-  {
-    "start_date": "2024-10-11T07:46:20Z",
-    "average_watts": 187.8,
-    "average_speed": 5.814,
-    "distance": 23545.0,
-    "moving_time": 4050,
-    "total_elevation_gain": 216.0
-  },
-  {
-    "start_date": "2024-10-14T06:05:49Z",
-    "average_watts": 171.1,
-    "average_speed": 8.375,
-    "distance": 18282.0,
-    "moving_time": 2183,
-    "total_elevation_gain": 97.3
-  },
-  {
-    "start_date": "2024-10-16T19:34:50Z",
-    "average_watts": 177.5,
-    "average_speed": 8.438,
-    "distance": 23169.7,
-    "moving_time": 2746,
-    "total_elevation_gain": 136.2
-  },
-  {
-    "start_date": "2024-10-17T18:39:56Z",
-    "average_watts": 181.3,
-    "average_speed": 3.592,
-    "distance": 5797.4,
-    "moving_time": 1614,
-    "total_elevation_gain": 82.5
-  },
-  {
-    "start_date": "2024-10-18T12:38:19Z",
-    "average_watts": 187.4,
-    "average_speed": 5.272,
-    "distance": 32772.7,
-    "moving_time": 6216,
-    "total_elevation_gain": 446.2
-  },
-  {
-    "start_date": "2024-10-19T15:40:54Z",
-    "average_watts": 167.1,
-    "average_speed": 7.386,
-    "distance": 27048.1,
-    "moving_time": 3662,
-    "total_elevation_gain": 382.2
-  },
-  {
-    "start_date": "2024-10-21T17:51:31Z",
-    "average_watts": 162.2,
-    "average_speed": 7.487,
-    "distance": 24587.4,
-    "moving_time": 3284,
-    "total_elevation_gain": 286.1
-  },
-  {
-    "start_date": "2024-10-23T15:45:29Z",
-    "average_watts": 176.2,
-    "average_speed": 6.146,
-    "distance": 33936.1,
-    "moving_time": 5522,
-    "total_elevation_gain": 485.5
-  },
-  {
-    "start_date": "2024-10-25T09:27:32Z",
-    "average_watts": 157.0,
-    "average_speed": 9.143,
-    "distance": 17526.6,
-    "moving_time": 1917,
-    "total_elevation_gain": 132.2
-  },
-  {
-    "start_date": "2024-10-26T10:24:09Z",
-    "average_watts": 157.7,
-    "average_speed": 6.76,
-    "distance": 91484.2,
-    "moving_time": 13533,
-    "total_elevation_gain": 1188.9
-  },
-  {
-    "start_date": "2024-10-27T14:04:41Z",
-    "average_watts": 168.2,
-    "average_speed": 7.129,
-    "distance": 16490.0,
-    "moving_time": 2313,
-    "total_elevation_gain": 173.0
-  },
-  {
-    "start_date": "2024-10-28T07:04:28Z",
-    "average_watts": 159.6,
-    "average_speed": 8.836,
-    "distance": 20374.8,
-    "moving_time": 2306,
-    "total_elevation_gain": 163.4
-  },
-  {
-    "start_date": "2024-10-31T19:11:20Z",
-    "average_watts": 173.2,
-    "average_speed": 5.746,
-    "distance": 4711.7,
-    "moving_time": 820,
-    "total_elevation_gain": 35.5
-  },
-  {
-    "start_date": "2024-11-04T16:32:06Z",
-    "average_watts": 191.7,
-    "average_speed": 8.868,
-    "distance": 16325.1,
-    "moving_time": 1841,
-    "total_elevation_gain": 196.0
-  },
-  {
-    "start_date": "2024-11-07T19:57:03Z",
-    "average_watts": 170.2,
-    "average_speed": 5.77,
-    "distance": 6485.0,
-    "moving_time": 1124,
-    "total_elevation_gain": 87.6
-  },
-  {
-    "start_date": "2024-11-11T12:06:41Z",
-    "average_watts": 166.0,
-    "average_speed": 5.507,
-    "distance": 31467.9,
-    "moving_time": 5714,
-    "total_elevation_gain": 292.3
-  },
-  {
-    "start_date": "2024-11-14T12:58:59Z",
-    "average_watts": 179.1,
-    "average_speed": 6.889,
-    "distance": 86035.9,
-    "moving_time": 12489,
-    "total_elevation_gain": 966.5
-  },
-  {
-    "start_date": "2024-11-15T10:29:51Z",
-    "average_watts": 160.8,
-    "average_speed": 5.814,
-    "distance": 27930.0,
-    "moving_time": 4804,
-    "total_elevation_gain": 224.0
-  },
-  {
-    "start_date": "2024-11-16T13:13:45Z",
-    "average_watts": 183.5,
-    "average_speed": 5.776,
-    "distance": 35561.1,
-    "moving_time": 6157,
-    "total_elevation_gain": 516.9
-  },
-  {
-    "start_date": "2024-11-17T08:39:38Z",
-    "average_watts": 182.6,
-    "average_speed": 7.377,
-    "distance": 37165.4,
-    "moving_time": 5038,
-    "total_elevation_gain": 489.3
-  },
-  {
-    "start_date": "2024-11-18T12:11:27Z",
-    "average_watts": 175.7,
-    "average_speed": 6.578,
-    "distance": 74637.4,
-    "moving_time": 11346,
-    "total_elevation_gain": 704.3
-  },
-  {
-    "start_date": "2024-11-22T10:00:48Z",
-    "average_watts": 167.6,
-    "average_speed": 5.496,
-    "distance": 3847.2,
-    "moving_time": 700,
-    "total_elevation_gain": 40.6
-  },
-  {
-    "start_date": "2024-11-24T07:56:39Z",
-    "average_watts": 168.9,
-    "average_speed": 6.578,
-    "distance": 26305.2,
-    "moving_time": 3999,
-    "total_elevation_gain": 132.9
-  },
-  {
-    "start_date": "2024-11-25T18:18:27Z",
-    "average_watts": 173.7,
-    "average_speed": 7.151,
-    "distance": 21187.9,
-    "moving_time": 2963,
-    "total_elevation_gain": 310.2
-  },
-  {
-    "start_date": "2024-11-26T13:04:29Z",
-    "average_watts": 186.2,
-    "average_speed": 6.144,
-    "distance": 25462.0,
-    "moving_time": 4144,
-    "total_elevation_gain": 251.2
-  },
-  {
-    "start_date": "2024-11-29T11:57:17Z",
-    "average_watts": 166.6,
-    "average_speed": 8.078,
-    "distance": 24370.9,
-    "moving_time": 3017,
-    "total_elevation_gain": 195.1
-  },
-  {
-    "start_date": "2024-11-30T15:43:45Z",
-    "average_watts": 175.5,
-    "average_speed": 9.385,
-    "distance": 17813.4,
-    "moving_time": 1898,
-    "total_elevation_gain": 177.3
-  },
-  {
-    "start_date": "2024-12-01T10:12:00Z",
-    "average_watts": 153.3,
-    "average_speed": 6.235,
-    "distance": 70266.6,
-    "moving_time": 11270,
-    "total_elevation_gain": 775.8
-  },
-  {
-    "start_date": "2024-12-02T07:57:12Z",
-    "average_watts": 157.1,
-    "average_speed": 7.457,
-    "distance": 18857.8,
-    "moving_time": 2529,
-    "total_elevation_gain": 103.9
-  },
-  {
-    "start_date": "2024-12-08T16:57:20Z",
-    "average_watts": 176.3,
-    "average_speed": 9.727,
-    "distance": 15446.4,
-    "moving_time": 1588,
-    "total_elevation_gain": 147.6
-  },
-  {
-    "start_date": "2024-12-09T12:55:00Z",
-    "average_watts": 170.1,
-    "average_speed": 6.022,
-    "distance": 96022.7,
-    "moving_time": 15945,
-    "total_elevation_gain": 1245.7
-  },
-  {
-    "start_date": "2024-12-11T08:21:29Z",
-    "average_watts": 161.6,
-    "average_speed": 4.772,
-    "distance": 7253.9,
-    "moving_time": 1520,
-    "total_elevation_gain": 42.1
-  },
-  {
-    "start_date": "2024-12-13T18:12:30Z",
-    "average_watts": 155.8,
-    "average_speed": 5.221,
-    "distance": 3988.9,
+    "average_speed": 5.195,
+    "distance": 71328.1,
+    "moving_time": 13731,
+    "total_elevation_gain": 447.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-23T18:22:04Z",
+    "average_watts": 147.1,
+    "average_speed": 5.347,
+    "distance": 6170.4,
+    "moving_time": 1154,
+    "total_elevation_gain": 32.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-25T18:13:44Z",
+    "average_watts": 159.4,
+    "average_speed": 4.546,
+    "distance": 5183.0,
+    "moving_time": 1140,
+    "total_elevation_gain": 29.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-29T15:32:17Z",
+    "average_watts": 160.1,
+    "average_speed": 5.661,
+    "distance": 64348.5,
+    "moving_time": 11366,
+    "total_elevation_gain": 785.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-30T17:19:11Z",
+    "average_watts": 162.9,
+    "average_speed": 8.42,
+    "distance": 15409.0,
+    "moving_time": 1830,
+    "total_elevation_gain": 97.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-05-31T10:59:09Z",
+    "average_watts": 134.6,
+    "average_speed": 7.265,
+    "distance": 27599.6,
+    "moving_time": 3799,
+    "total_elevation_gain": 265.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-06-03T14:32:13Z",
+    "average_watts": 159.4,
+    "average_speed": 7.687,
+    "distance": 27586.9,
+    "moving_time": 3589,
+    "total_elevation_gain": 253.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-06-06T18:28:20Z",
+    "average_watts": 133.4,
+    "average_speed": 4.434,
+    "distance": 3387.8,
     "moving_time": 764,
-    "total_elevation_gain": 36.1
+    "total_elevation_gain": 37.7,
+    "type": "Ride"
   },
   {
-    "start_date": "2024-12-24T11:35:30Z",
-    "average_watts": 159.3,
-    "average_speed": 7.518,
-    "distance": 20012.7,
-    "moving_time": 2662,
-    "total_elevation_gain": 115.8
+    "start_date": "2020-06-07T15:54:31Z",
+    "average_watts": 169.9,
+    "average_speed": 3.255,
+    "distance": 3896.1,
+    "moving_time": 1197,
+    "total_elevation_gain": 22.0,
+    "type": "Ride"
   },
   {
-    "start_date": "2024-12-27T06:58:27Z",
-    "average_watts": 191.3,
-    "average_speed": 6.52,
-    "distance": 31601.3,
-    "moving_time": 4847,
-    "total_elevation_gain": 302.5
+    "start_date": "2020-06-08T07:35:02Z",
+    "average_watts": 134.5,
+    "average_speed": 6.661,
+    "distance": 51590.0,
+    "moving_time": 7745,
+    "total_elevation_gain": 451.1,
+    "type": "Ride"
   },
   {
-    "start_date": "2024-12-30T19:51:45Z",
-    "average_watts": 157.8,
-    "average_speed": 5.448,
-    "distance": 98272.2,
-    "moving_time": 18039,
-    "total_elevation_gain": 1012.8
+    "start_date": "2020-06-09T08:50:01Z",
+    "average_watts": 130.7,
+    "average_speed": 5.3,
+    "distance": 30404.8,
+    "moving_time": 5737,
+    "total_elevation_gain": 228.4,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-01-02T09:16:50Z",
-    "average_watts": 157.1,
-    "average_speed": 6.382,
-    "distance": 56063.0,
-    "moving_time": 8784,
-    "total_elevation_gain": 297.1
+    "start_date": "2020-06-10T07:00:21Z",
+    "average_watts": 148.2,
+    "average_speed": 9.636,
+    "distance": 10002.0,
+    "moving_time": 1038,
+    "total_elevation_gain": 58.7,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-01-03T17:13:14Z",
-    "average_watts": 160.6,
-    "average_speed": 5.224,
-    "distance": 4090.6,
-    "moving_time": 783,
-    "total_elevation_gain": 35.1
+    "start_date": "2020-06-11T15:13:12Z",
+    "average_watts": 134.0,
+    "average_speed": 5.989,
+    "distance": 23014.1,
+    "moving_time": 3843,
+    "total_elevation_gain": 185.7,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-01-05T19:43:50Z",
-    "average_watts": 189.6,
-    "average_speed": 5.515,
-    "distance": 22364.3,
-    "moving_time": 4055,
-    "total_elevation_gain": 193.9
+    "start_date": "2020-06-12T12:46:11Z",
+    "average_watts": 160.2,
+    "average_speed": 8.382,
+    "distance": 18960.7,
+    "moving_time": 2262,
+    "total_elevation_gain": 231.1,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-01-06T15:43:04Z",
-    "average_watts": 171.2,
-    "average_speed": 5.646,
-    "distance": 5064.0,
-    "moving_time": 897,
-    "total_elevation_gain": 53.1
-  },
-  {
-    "start_date": "2025-01-09T10:42:12Z",
-    "average_watts": 154.0,
-    "average_speed": 7.027,
-    "distance": 25017.7,
-    "moving_time": 3560,
-    "total_elevation_gain": 300.5
-  },
-  {
-    "start_date": "2025-01-10T11:16:23Z",
-    "average_watts": 177.1,
-    "average_speed": 7.173,
-    "distance": 30587.2,
-    "moving_time": 4264,
-    "total_elevation_gain": 423.0
-  },
-  {
-    "start_date": "2025-01-12T11:25:51Z",
-    "average_watts": 177.0,
-    "average_speed": 3.02,
-    "distance": 5255.1,
-    "moving_time": 1740,
-    "total_elevation_gain": 55.6
-  },
-  {
-    "start_date": "2025-01-14T19:37:51Z",
-    "average_watts": 173.1,
-    "average_speed": 4.066,
-    "distance": 6423.8,
-    "moving_time": 1580,
-    "total_elevation_gain": 41.7
-  },
-  {
-    "start_date": "2025-01-17T06:19:15Z",
-    "average_watts": 188.4,
-    "average_speed": 6.3,
-    "distance": 59316.8,
-    "moving_time": 9416,
-    "total_elevation_gain": 508.7
-  },
-  {
-    "start_date": "2025-01-18T15:28:26Z",
-    "average_watts": 179.6,
-    "average_speed": 9.876,
-    "distance": 17400.7,
-    "moving_time": 1762,
-    "total_elevation_gain": 242.5
-  },
-  {
-    "start_date": "2025-01-20T11:09:26Z",
-    "average_watts": 180.6,
-    "average_speed": 6.364,
-    "distance": 99917.0,
-    "moving_time": 15701,
-    "total_elevation_gain": 1374.4
-  },
-  {
-    "start_date": "2025-01-21T14:55:12Z",
-    "average_watts": 182.3,
-    "average_speed": 6.454,
-    "distance": 60846.3,
-    "moving_time": 9427,
-    "total_elevation_gain": 810.3
-  },
-  {
-    "start_date": "2025-01-22T15:58:00Z",
-    "average_watts": 175.7,
-    "average_speed": 6.174,
-    "distance": 85229.1,
-    "moving_time": 13804,
-    "total_elevation_gain": 641.7
-  },
-  {
-    "start_date": "2025-01-24T16:11:45Z",
-    "average_watts": 189.9,
-    "average_speed": 9.006,
-    "distance": 15292.3,
-    "moving_time": 1698,
-    "total_elevation_gain": 223.5
-  },
-  {
-    "start_date": "2025-01-30T17:00:30Z",
-    "average_watts": 162.0,
-    "average_speed": 7.784,
-    "distance": 23702.7,
-    "moving_time": 3045,
-    "total_elevation_gain": 304.2
-  },
-  {
-    "start_date": "2025-02-02T08:58:40Z",
-    "average_watts": 185.3,
-    "average_speed": 6.491,
-    "distance": 51646.2,
-    "moving_time": 7957,
-    "total_elevation_gain": 373.7
-  },
-  {
-    "start_date": "2025-02-03T19:09:43Z",
-    "average_watts": 174.3,
-    "average_speed": 4.452,
-    "distance": 6126.0,
-    "moving_time": 1376,
-    "total_elevation_gain": 44.6
-  },
-  {
-    "start_date": "2025-02-04T07:44:55Z",
-    "average_watts": 184.1,
-    "average_speed": 9.474,
-    "distance": 10279.8,
-    "moving_time": 1085,
-    "total_elevation_gain": 70.1
-  },
-  {
-    "start_date": "2025-02-05T07:23:18Z",
-    "average_watts": 179.9,
-    "average_speed": 3.331,
-    "distance": 6256.2,
-    "moving_time": 1878,
-    "total_elevation_gain": 66.4
-  },
-  {
-    "start_date": "2025-02-07T06:48:11Z",
-    "average_watts": 168.1,
-    "average_speed": 5.213,
-    "distance": 37174.3,
-    "moving_time": 7131,
-    "total_elevation_gain": 515.1
-  },
-  {
-    "start_date": "2025-02-08T10:52:58Z",
-    "average_watts": 179.7,
-    "average_speed": 7.289,
-    "distance": 13055.3,
-    "moving_time": 1791,
-    "total_elevation_gain": 154.1
-  },
-  {
-    "start_date": "2025-02-09T14:15:46Z",
-    "average_watts": 184.6,
-    "average_speed": 9.928,
-    "distance": 22774.2,
-    "moving_time": 2294,
-    "total_elevation_gain": 284.7
-  },
-  {
-    "start_date": "2025-02-11T13:02:39Z",
-    "average_watts": 183.4,
-    "average_speed": 7.856,
-    "distance": 15948.5,
-    "moving_time": 2030,
-    "total_elevation_gain": 103.1
-  },
-  {
-    "start_date": "2025-02-13T16:42:41Z",
-    "average_watts": 175.1,
-    "average_speed": 4.103,
-    "distance": 3738.2,
-    "moving_time": 911,
-    "total_elevation_gain": 22.2
-  },
-  {
-    "start_date": "2025-02-15T14:30:10Z",
-    "average_watts": 163.9,
-    "average_speed": 7.671,
-    "distance": 39297.7,
-    "moving_time": 5123,
-    "total_elevation_gain": 471.8
-  },
-  {
-    "start_date": "2025-02-17T18:43:37Z",
-    "average_watts": 164.7,
-    "average_speed": 6.815,
-    "distance": 38677.6,
-    "moving_time": 5675,
-    "total_elevation_gain": 550.1
-  },
-  {
-    "start_date": "2025-02-20T15:26:50Z",
-    "average_watts": 182.3,
-    "average_speed": 6.616,
-    "distance": 32539.8,
-    "moving_time": 4918,
-    "total_elevation_gain": 453.8
-  },
-  {
-    "start_date": "2025-02-24T08:36:39Z",
-    "average_watts": 165.7,
-    "average_speed": 8.026,
-    "distance": 14406.8,
-    "moving_time": 1795,
-    "total_elevation_gain": 199.2
-  },
-  {
-    "start_date": "2025-02-26T14:42:42Z",
-    "average_watts": 180.7,
-    "average_speed": 7.43,
-    "distance": 18336.3,
-    "moving_time": 2468,
-    "total_elevation_gain": 228.3
-  },
-  {
-    "start_date": "2025-03-01T07:32:34Z",
-    "average_watts": 167.4,
-    "average_speed": 6.475,
-    "distance": 26626.2,
-    "moving_time": 4112,
-    "total_elevation_gain": 206.0
-  },
-  {
-    "start_date": "2025-03-02T11:30:15Z",
-    "average_watts": 172.4,
-    "average_speed": 7.52,
-    "distance": 21756.4,
-    "moving_time": 2893,
-    "total_elevation_gain": 173.4
-  },
-  {
-    "start_date": "2025-03-04T08:21:44Z",
-    "average_watts": 158.4,
-    "average_speed": 8.206,
-    "distance": 11308.4,
-    "moving_time": 1378,
-    "total_elevation_gain": 134.0
-  },
-  {
-    "start_date": "2025-03-06T06:06:32Z",
-    "average_watts": 158.4,
-    "average_speed": 6.384,
-    "distance": 32235.3,
-    "moving_time": 5049,
-    "total_elevation_gain": 415.1
-  },
-  {
-    "start_date": "2025-03-07T11:02:01Z",
-    "average_watts": 155.7,
-    "average_speed": 5.494,
-    "distance": 3082.0,
-    "moving_time": 561,
-    "total_elevation_gain": 41.9
-  },
-  {
-    "start_date": "2025-03-08T09:03:12Z",
-    "average_watts": 188.1,
-    "average_speed": 7.349,
-    "distance": 14418.4,
-    "moving_time": 1962,
-    "total_elevation_gain": 93.1
-  },
-  {
-    "start_date": "2025-03-09T12:34:07Z",
-    "average_watts": 191.9,
-    "average_speed": 4.971,
-    "distance": 3748.2,
-    "moving_time": 754,
-    "total_elevation_gain": 22.2
-  },
-  {
-    "start_date": "2025-03-10T08:35:44Z",
-    "average_watts": 162.2,
-    "average_speed": 6.991,
-    "distance": 94663.1,
-    "moving_time": 13540,
-    "total_elevation_gain": 726.0
-  },
-  {
-    "start_date": "2025-03-11T15:22:15Z",
-    "average_watts": 157.1,
-    "average_speed": 6.144,
-    "distance": 30258.8,
-    "moving_time": 4925,
-    "total_elevation_gain": 290.2
-  },
-  {
-    "start_date": "2025-03-13T07:29:52Z",
-    "average_watts": 180.3,
-    "average_speed": 5.915,
-    "distance": 6725.1,
-    "moving_time": 1137,
-    "total_elevation_gain": 87.9
-  },
-  {
-    "start_date": "2025-03-14T13:02:43Z",
-    "average_watts": 174.1,
-    "average_speed": 6.075,
-    "distance": 80310.4,
-    "moving_time": 13219,
-    "total_elevation_gain": 1133.0
-  },
-  {
-    "start_date": "2025-03-15T06:42:39Z",
-    "average_watts": 165.9,
-    "average_speed": 4.87,
-    "distance": 7183.6,
-    "moving_time": 1475,
-    "total_elevation_gain": 65.1
-  },
-  {
-    "start_date": "2025-03-16T14:07:00Z",
-    "average_watts": 183.1,
-    "average_speed": 9.402,
-    "distance": 20252.8,
+    "start_date": "2020-06-14T17:48:49Z",
+    "average_watts": 153.6,
+    "average_speed": 8.797,
+    "distance": 18948.5,
     "moving_time": 2154,
-    "total_elevation_gain": 173.4
+    "total_elevation_gain": 283.6,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-03-19T11:29:05Z",
-    "average_watts": 158.3,
-    "average_speed": 6.183,
-    "distance": 33238.4,
-    "moving_time": 5376,
-    "total_elevation_gain": 180.1
+    "start_date": "2020-06-16T18:39:02Z",
+    "average_watts": 149.7,
+    "average_speed": 6.28,
+    "distance": 94039.0,
+    "moving_time": 14975,
+    "total_elevation_gain": 728.2,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-03-20T18:08:25Z",
-    "average_watts": 171.7,
-    "average_speed": 8.407,
-    "distance": 11307.6,
-    "moving_time": 1345,
-    "total_elevation_gain": 107.3
+    "start_date": "2020-06-19T08:45:43Z",
+    "average_watts": 148.3,
+    "average_speed": 7.517,
+    "distance": 28420.0,
+    "moving_time": 3781,
+    "total_elevation_gain": 312.1,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-03-22T08:33:03Z",
-    "average_watts": 183.8,
-    "average_speed": 5.348,
-    "distance": 32751.4,
-    "moving_time": 6124,
-    "total_elevation_gain": 487.2
+    "start_date": "2020-06-21T09:37:45Z",
+    "average_watts": 138.8,
+    "average_speed": 3.137,
+    "distance": 4332.1,
+    "moving_time": 1381,
+    "total_elevation_gain": 36.8,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-03-23T14:35:18Z",
-    "average_watts": 155.7,
-    "average_speed": 9.589,
-    "distance": 13031.0,
-    "moving_time": 1359,
-    "total_elevation_gain": 107.7
+    "start_date": "2020-06-24T10:22:57Z",
+    "average_watts": 151.4,
+    "average_speed": 6.078,
+    "distance": 26463.2,
+    "moving_time": 4354,
+    "total_elevation_gain": 164.2,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-03-24T08:14:36Z",
-    "average_watts": 167.0,
-    "average_speed": 5.277,
-    "distance": 61592.7,
-    "moving_time": 11672,
-    "total_elevation_gain": 425.6
+    "start_date": "2020-06-25T12:57:00Z",
+    "average_watts": 137.8,
+    "average_speed": 9.836,
+    "distance": 20074.8,
+    "moving_time": 2041,
+    "total_elevation_gain": 112.5,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-03-25T11:25:18Z",
-    "average_watts": 160.6,
-    "average_speed": 5.541,
-    "distance": 39372.5,
-    "moving_time": 7106,
-    "total_elevation_gain": 323.2
-  },
-  {
-    "start_date": "2025-03-26T19:17:35Z",
-    "average_watts": 168.9,
-    "average_speed": 8.225,
-    "distance": 14961.8,
-    "moving_time": 1819,
-    "total_elevation_gain": 125.5
-  },
-  {
-    "start_date": "2025-03-28T18:18:56Z",
-    "average_watts": 157.4,
-    "average_speed": 7.586,
-    "distance": 20800.8,
-    "moving_time": 2742,
-    "total_elevation_gain": 168.0
-  },
-  {
-    "start_date": "2025-03-30T14:25:34Z",
-    "average_watts": 180.3,
-    "average_speed": 3.529,
-    "distance": 3928.1,
-    "moving_time": 1113,
-    "total_elevation_gain": 30.9
-  },
-  {
-    "start_date": "2025-03-31T12:39:53Z",
-    "average_watts": 169.0,
-    "average_speed": 4.423,
-    "distance": 6828.7,
-    "moving_time": 1544,
-    "total_elevation_gain": 82.8
-  },
-  {
-    "start_date": "2025-04-02T10:13:22Z",
-    "average_watts": 183.5,
-    "average_speed": 6.216,
-    "distance": 29689.6,
-    "moving_time": 4776,
-    "total_elevation_gain": 379.7
-  },
-  {
-    "start_date": "2025-04-03T09:01:38Z",
-    "average_watts": 171.2,
-    "average_speed": 4.407,
-    "distance": 5663.6,
-    "moving_time": 1285,
-    "total_elevation_gain": 50.1
-  },
-  {
-    "start_date": "2025-04-04T07:38:17Z",
-    "average_watts": 162.0,
-    "average_speed": 7.976,
-    "distance": 14429.0,
-    "moving_time": 1809,
-    "total_elevation_gain": 138.0
-  },
-  {
-    "start_date": "2025-04-05T13:11:15Z",
-    "average_watts": 162.0,
-    "average_speed": 9.203,
-    "distance": 22299.3,
-    "moving_time": 2423,
-    "total_elevation_gain": 171.4
-  },
-  {
-    "start_date": "2025-04-08T07:17:52Z",
-    "average_watts": 180.5,
-    "average_speed": 5.117,
-    "distance": 6682.2,
-    "moving_time": 1306,
-    "total_elevation_gain": 67.4
-  },
-  {
-    "start_date": "2025-04-09T14:33:54Z",
-    "average_watts": 157.4,
-    "average_speed": 5.223,
-    "distance": 7809.1,
-    "moving_time": 1495,
-    "total_elevation_gain": 83.0
-  },
-  {
-    "start_date": "2025-04-12T16:25:05Z",
-    "average_watts": 179.5,
-    "average_speed": 9.421,
-    "distance": 12934.7,
-    "moving_time": 1373,
-    "total_elevation_gain": 180.3
-  },
-  {
-    "start_date": "2025-04-13T08:08:25Z",
-    "average_watts": 180.2,
-    "average_speed": 7.188,
-    "distance": 20412.7,
-    "moving_time": 2840,
-    "total_elevation_gain": 300.0
-  },
-  {
-    "start_date": "2025-04-14T17:32:25Z",
-    "average_watts": 156.0,
-    "average_speed": 3.547,
-    "distance": 7750.4,
-    "moving_time": 2185,
-    "total_elevation_gain": 44.1
-  },
-  {
-    "start_date": "2025-04-15T11:39:43Z",
-    "average_watts": 155.3,
-    "average_speed": 8.386,
-    "distance": 20194.3,
-    "moving_time": 2408,
-    "total_elevation_gain": 235.6
-  },
-  {
-    "start_date": "2025-04-16T14:33:29Z",
-    "average_watts": 179.6,
-    "average_speed": 4.085,
-    "distance": 4391.0,
-    "moving_time": 1075,
-    "total_elevation_gain": 24.5
-  },
-  {
-    "start_date": "2025-04-18T06:38:08Z",
-    "average_watts": 157.7,
-    "average_speed": 6.26,
-    "distance": 96838.1,
-    "moving_time": 15469,
-    "total_elevation_gain": 611.3
-  },
-  {
-    "start_date": "2025-04-19T14:18:30Z",
-    "average_watts": 185.1,
-    "average_speed": 8.23,
-    "distance": 18724.3,
-    "moving_time": 2275,
-    "total_elevation_gain": 194.3
-  },
-  {
-    "start_date": "2025-04-24T19:44:23Z",
-    "average_watts": 155.7,
-    "average_speed": 7.063,
-    "distance": 13808.5,
-    "moving_time": 1955,
-    "total_elevation_gain": 197.1
-  },
-  {
-    "start_date": "2025-04-25T07:12:00Z",
+    "start_date": "2020-06-29T12:01:02Z",
     "average_watts": 161.9,
-    "average_speed": 6.479,
-    "distance": 66817.2,
-    "moving_time": 10313,
-    "total_elevation_gain": 858.5
+    "average_speed": 5.584,
+    "distance": 84134.4,
+    "moving_time": 15068,
+    "total_elevation_gain": 1087.9,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-04-26T08:19:05Z",
+    "start_date": "2020-06-30T09:54:50Z",
+    "average_watts": 165.5,
+    "average_speed": 5.473,
+    "distance": 86520.6,
+    "moving_time": 15810,
+    "total_elevation_gain": 816.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-01T17:58:53Z",
+    "average_watts": 160.3,
+    "average_speed": 3.867,
+    "distance": 3193.8,
+    "moving_time": 826,
+    "total_elevation_gain": 42.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-02T10:23:59Z",
+    "average_watts": 161.4,
+    "average_speed": 7.88,
+    "distance": 29274.4,
+    "moving_time": 3715,
+    "total_elevation_gain": 348.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-07T18:00:30Z",
+    "average_watts": 143.5,
+    "average_speed": 5.821,
+    "distance": 93519.9,
+    "moving_time": 16065,
+    "total_elevation_gain": 925.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-09T13:46:35Z",
+    "average_watts": 155.9,
+    "average_speed": 7.127,
+    "distance": 20633.8,
+    "moving_time": 2895,
+    "total_elevation_gain": 205.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-10T12:40:34Z",
+    "average_watts": 169.6,
+    "average_speed": 5.551,
+    "distance": 99513.9,
+    "moving_time": 17926,
+    "total_elevation_gain": 925.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-13T06:45:28Z",
+    "average_watts": 154.0,
+    "average_speed": 8.711,
+    "distance": 14834.9,
+    "moving_time": 1703,
+    "total_elevation_gain": 206.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-20T18:54:40Z",
+    "average_watts": 159.3,
+    "average_speed": 7.604,
+    "distance": 24825.6,
+    "moving_time": 3265,
+    "total_elevation_gain": 280.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-23T06:20:26Z",
+    "average_watts": 155.3,
+    "average_speed": 7.25,
+    "distance": 33465.2,
+    "moving_time": 4616,
+    "total_elevation_gain": 231.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-24T13:02:55Z",
+    "average_watts": 153.2,
+    "average_speed": 4.027,
+    "distance": 6995.5,
+    "moving_time": 1737,
+    "total_elevation_gain": 61.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-25T17:58:01Z",
+    "average_watts": 152.4,
+    "average_speed": 3.088,
+    "distance": 4385.3,
+    "moving_time": 1420,
+    "total_elevation_gain": 49.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-27T13:45:14Z",
+    "average_watts": 166.2,
+    "average_speed": 8.981,
+    "distance": 21347.7,
+    "moving_time": 2377,
+    "total_elevation_gain": 237.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-07-31T13:36:07Z",
+    "average_watts": 135.4,
+    "average_speed": 7.762,
+    "distance": 20733.4,
+    "moving_time": 2671,
+    "total_elevation_gain": 257.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-01T17:13:17Z",
+    "average_watts": 171.1,
+    "average_speed": 4.898,
+    "distance": 3002.8,
+    "moving_time": 613,
+    "total_elevation_gain": 33.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-02T10:43:06Z",
+    "average_watts": 147.8,
+    "average_speed": 5.702,
+    "distance": 7988.8,
+    "moving_time": 1401,
+    "total_elevation_gain": 73.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-03T18:06:57Z",
+    "average_watts": 149.2,
+    "average_speed": 7.664,
+    "distance": 16315.7,
+    "moving_time": 2129,
+    "total_elevation_gain": 173.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-05T19:01:38Z",
+    "average_watts": 148.7,
+    "average_speed": 4.524,
+    "distance": 5998.3,
+    "moving_time": 1326,
+    "total_elevation_gain": 49.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-06T18:36:20Z",
+    "average_watts": 148.2,
+    "average_speed": 5.492,
+    "distance": 38700.9,
+    "moving_time": 7047,
+    "total_elevation_gain": 423.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-08T18:56:56Z",
+    "average_watts": 150.3,
+    "average_speed": 9.367,
+    "distance": 17141.2,
+    "moving_time": 1830,
+    "total_elevation_gain": 221.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-12T12:54:27Z",
+    "average_watts": 149.1,
+    "average_speed": 7.239,
+    "distance": 17843.4,
+    "moving_time": 2465,
+    "total_elevation_gain": 123.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-13T19:42:19Z",
+    "average_watts": 146.1,
+    "average_speed": 8.769,
+    "distance": 21492.6,
+    "moving_time": 2451,
+    "total_elevation_gain": 259.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-16T15:49:47Z",
+    "average_watts": 156.8,
+    "average_speed": 7.13,
+    "distance": 29783.9,
+    "moving_time": 4177,
+    "total_elevation_gain": 436.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-19T19:30:52Z",
+    "average_watts": 132.1,
+    "average_speed": 8.781,
+    "distance": 15788.8,
+    "moving_time": 1798,
+    "total_elevation_gain": 105.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-22T17:49:27Z",
+    "average_watts": 138.6,
+    "average_speed": 7.575,
+    "distance": 12203.1,
+    "moving_time": 1611,
+    "total_elevation_gain": 140.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-24T13:58:17Z",
+    "average_watts": 146.7,
+    "average_speed": 8.672,
+    "distance": 20085.1,
+    "moving_time": 2316,
+    "total_elevation_gain": 183.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-25T19:19:13Z",
+    "average_watts": 140.2,
+    "average_speed": 4.471,
+    "distance": 5928.6,
+    "moving_time": 1326,
+    "total_elevation_gain": 60.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-26T16:42:11Z",
+    "average_watts": 157.5,
+    "average_speed": 4.37,
+    "distance": 7210.5,
+    "moving_time": 1650,
+    "total_elevation_gain": 72.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-27T18:41:03Z",
+    "average_watts": 147.1,
+    "average_speed": 4.786,
+    "distance": 3025.0,
+    "moving_time": 632,
+    "total_elevation_gain": 44.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-08-30T12:44:34Z",
+    "average_watts": 151.3,
+    "average_speed": 5.71,
+    "distance": 80747.4,
+    "moving_time": 14141,
+    "total_elevation_gain": 1087.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-01T15:34:42Z",
+    "average_watts": 164.4,
+    "average_speed": 5.445,
+    "distance": 3299.7,
+    "moving_time": 606,
+    "total_elevation_gain": 44.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-02T09:42:55Z",
+    "average_watts": 133.6,
+    "average_speed": 7.032,
+    "distance": 15736.6,
+    "moving_time": 2238,
+    "total_elevation_gain": 94.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-05T10:22:03Z",
+    "average_watts": 144.2,
+    "average_speed": 5.199,
+    "distance": 3369.1,
+    "moving_time": 648,
+    "total_elevation_gain": 21.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-09T16:48:18Z",
+    "average_watts": 145.3,
+    "average_speed": 3.139,
+    "distance": 3088.8,
+    "moving_time": 984,
+    "total_elevation_gain": 27.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-10T09:15:36Z",
+    "average_watts": 135.6,
+    "average_speed": 5.688,
+    "distance": 56269.7,
+    "moving_time": 9892,
+    "total_elevation_gain": 549.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-11T09:28:30Z",
+    "average_watts": 167.3,
+    "average_speed": 5.134,
+    "distance": 62260.5,
+    "moving_time": 12127,
+    "total_elevation_gain": 393.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-14T17:57:45Z",
+    "average_watts": 150.8,
+    "average_speed": 6.714,
+    "distance": 99685.3,
+    "moving_time": 14847,
+    "total_elevation_gain": 1236.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-15T13:49:19Z",
+    "average_watts": 156.7,
+    "average_speed": 5.251,
+    "distance": 39873.0,
+    "moving_time": 7593,
+    "total_elevation_gain": 412.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-19T19:40:48Z",
+    "average_watts": 159.6,
+    "average_speed": 6.35,
+    "distance": 62981.8,
+    "moving_time": 9919,
+    "total_elevation_gain": 718.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-21T08:01:28Z",
+    "average_watts": 156.9,
+    "average_speed": 6.556,
+    "distance": 51250.5,
+    "moving_time": 7817,
+    "total_elevation_gain": 668.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-22T14:21:17Z",
+    "average_watts": 162.6,
+    "average_speed": 6.038,
+    "distance": 37589.2,
+    "moving_time": 6225,
+    "total_elevation_gain": 243.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-23T15:56:52Z",
+    "average_watts": 148.1,
+    "average_speed": 6.392,
+    "distance": 54283.8,
+    "moving_time": 8493,
+    "total_elevation_gain": 751.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-24T15:58:48Z",
+    "average_watts": 156.5,
+    "average_speed": 7.845,
+    "distance": 35638.7,
+    "moving_time": 4543,
+    "total_elevation_gain": 291.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-26T06:23:10Z",
+    "average_watts": 167.1,
+    "average_speed": 5.449,
+    "distance": 38103.8,
+    "moving_time": 6993,
+    "total_elevation_gain": 519.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-27T11:31:11Z",
+    "average_watts": 152.6,
+    "average_speed": 6.6,
+    "distance": 91473.5,
+    "moving_time": 13859,
+    "total_elevation_gain": 768.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-09-29T07:01:42Z",
+    "average_watts": 147.0,
+    "average_speed": 5.74,
+    "distance": 93711.3,
+    "moving_time": 16326,
+    "total_elevation_gain": 1361.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-02T10:04:16Z",
+    "average_watts": 151.2,
+    "average_speed": 9.717,
+    "distance": 15148.3,
+    "moving_time": 1559,
+    "total_elevation_gain": 134.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-03T11:22:57Z",
+    "average_watts": 163.6,
+    "average_speed": 7.809,
+    "distance": 12533.3,
+    "moving_time": 1605,
+    "total_elevation_gain": 174.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-04T13:38:17Z",
+    "average_watts": 145.0,
+    "average_speed": 7.626,
+    "distance": 23328.8,
+    "moving_time": 3059,
+    "total_elevation_gain": 132.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-05T10:03:25Z",
+    "average_watts": 167.7,
+    "average_speed": 6.324,
+    "distance": 68146.9,
+    "moving_time": 10776,
+    "total_elevation_gain": 458.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-06T06:17:08Z",
+    "average_watts": 166.2,
+    "average_speed": 7.848,
+    "distance": 18969.1,
+    "moving_time": 2417,
+    "total_elevation_gain": 137.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-07T08:31:43Z",
+    "average_watts": 154.2,
+    "average_speed": 5.766,
+    "distance": 33351.6,
+    "moving_time": 5784,
+    "total_elevation_gain": 357.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-10T13:21:48Z",
+    "average_watts": 142.7,
+    "average_speed": 6.726,
+    "distance": 37395.9,
+    "moving_time": 5560,
+    "total_elevation_gain": 341.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-12T18:18:58Z",
+    "average_watts": 166.0,
+    "average_speed": 5.211,
+    "distance": 34619.9,
+    "moving_time": 6643,
+    "total_elevation_gain": 272.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-17T15:03:14Z",
+    "average_watts": 153.1,
+    "average_speed": 3.261,
+    "distance": 6596.1,
+    "moving_time": 2023,
+    "total_elevation_gain": 74.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-18T06:18:30Z",
+    "average_watts": 133.6,
+    "average_speed": 5.735,
+    "distance": 92977.0,
+    "moving_time": 16211,
+    "total_elevation_gain": 942.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-19T12:42:48Z",
+    "average_watts": 148.4,
+    "average_speed": 7.815,
+    "distance": 27057.0,
+    "moving_time": 3462,
+    "total_elevation_gain": 294.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-21T08:30:12Z",
+    "average_watts": 158.9,
+    "average_speed": 4.898,
+    "distance": 4771.0,
+    "moving_time": 974,
+    "total_elevation_gain": 59.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-22T13:11:12Z",
+    "average_watts": 142.7,
+    "average_speed": 6.603,
+    "distance": 50038.2,
+    "moving_time": 7578,
+    "total_elevation_gain": 276.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-24T07:39:47Z",
+    "average_watts": 158.9,
+    "average_speed": 5.784,
+    "distance": 6304.8,
+    "moving_time": 1090,
+    "total_elevation_gain": 42.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-25T06:25:55Z",
+    "average_watts": 155.0,
+    "average_speed": 7.002,
+    "distance": 39601.5,
+    "moving_time": 5656,
+    "total_elevation_gain": 395.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-26T10:46:43Z",
+    "average_watts": 141.0,
+    "average_speed": 6.772,
+    "distance": 50589.6,
+    "moving_time": 7470,
+    "total_elevation_gain": 493.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-10-31T17:19:52Z",
+    "average_watts": 148.7,
+    "average_speed": 7.497,
+    "distance": 17018.1,
+    "moving_time": 2270,
+    "total_elevation_gain": 230.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-03T18:30:51Z",
+    "average_watts": 163.1,
+    "average_speed": 3.694,
+    "distance": 6770.8,
+    "moving_time": 1833,
+    "total_elevation_gain": 48.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-04T19:20:42Z",
+    "average_watts": 140.8,
+    "average_speed": 7.835,
+    "distance": 35365.9,
+    "moving_time": 4514,
+    "total_elevation_gain": 358.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-05T12:57:35Z",
+    "average_watts": 164.1,
+    "average_speed": 9.078,
+    "distance": 18782.0,
+    "moving_time": 2069,
+    "total_elevation_gain": 162.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-06T07:39:30Z",
+    "average_watts": 165.6,
+    "average_speed": 5.841,
+    "distance": 5350.4,
+    "moving_time": 916,
+    "total_elevation_gain": 78.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-07T18:29:29Z",
+    "average_watts": 153.8,
+    "average_speed": 5.709,
+    "distance": 4110.2,
+    "moving_time": 720,
+    "total_elevation_gain": 54.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-09T07:17:52Z",
+    "average_watts": 138.8,
+    "average_speed": 5.166,
+    "distance": 55977.3,
+    "moving_time": 10835,
+    "total_elevation_gain": 744.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-10T18:37:51Z",
+    "average_watts": 138.5,
+    "average_speed": 7.693,
+    "distance": 24401.1,
+    "moving_time": 3172,
+    "total_elevation_gain": 177.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-13T18:23:39Z",
+    "average_watts": 169.3,
+    "average_speed": 7.052,
+    "distance": 22403.9,
+    "moving_time": 3177,
+    "total_elevation_gain": 117.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-14T07:09:39Z",
+    "average_watts": 165.0,
+    "average_speed": 9.156,
+    "distance": 20162.4,
+    "moving_time": 2202,
+    "total_elevation_gain": 243.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-15T19:55:58Z",
+    "average_watts": 151.8,
+    "average_speed": 3.838,
+    "distance": 3949.4,
+    "moving_time": 1029,
+    "total_elevation_gain": 21.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-16T17:47:03Z",
+    "average_watts": 163.4,
+    "average_speed": 5.305,
+    "distance": 5576.0,
+    "moving_time": 1051,
+    "total_elevation_gain": 31.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-21T18:15:56Z",
+    "average_watts": 147.9,
+    "average_speed": 6.644,
+    "distance": 31737.4,
+    "moving_time": 4777,
+    "total_elevation_gain": 280.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-22T16:37:48Z",
+    "average_watts": 159.9,
+    "average_speed": 9.004,
+    "distance": 12155.7,
+    "moving_time": 1350,
+    "total_elevation_gain": 99.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-26T12:56:26Z",
+    "average_watts": 136.4,
+    "average_speed": 5.645,
+    "distance": 79489.7,
+    "moving_time": 14082,
+    "total_elevation_gain": 1174.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-28T09:02:33Z",
+    "average_watts": 145.1,
+    "average_speed": 5.302,
+    "distance": 31380.2,
+    "moving_time": 5918,
+    "total_elevation_gain": 273.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-11-29T06:09:51Z",
+    "average_watts": 135.7,
+    "average_speed": 6.205,
+    "distance": 58071.6,
+    "moving_time": 9359,
+    "total_elevation_gain": 838.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-01T16:23:42Z",
+    "average_watts": 134.1,
+    "average_speed": 7.738,
+    "distance": 23011.9,
+    "moving_time": 2974,
+    "total_elevation_gain": 299.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-07T07:15:08Z",
+    "average_watts": 140.9,
+    "average_speed": 8.851,
+    "distance": 16764.5,
+    "moving_time": 1894,
+    "total_elevation_gain": 195.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-08T08:36:56Z",
+    "average_watts": 140.2,
+    "average_speed": 6.836,
+    "distance": 95922.7,
+    "moving_time": 14033,
+    "total_elevation_gain": 1231.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-09T07:31:31Z",
+    "average_watts": 139.8,
+    "average_speed": 5.622,
+    "distance": 54019.4,
+    "moving_time": 9608,
+    "total_elevation_gain": 688.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-10T10:14:37Z",
     "average_watts": 168.5,
-    "average_speed": 6.601,
-    "distance": 30479.0,
-    "moving_time": 4617,
-    "total_elevation_gain": 245.3
+    "average_speed": 5.899,
+    "distance": 4577.8,
+    "moving_time": 776,
+    "total_elevation_gain": 35.7,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-04-27T08:57:53Z",
-    "average_watts": 184.3,
-    "average_speed": 8.425,
-    "distance": 23656.7,
-    "moving_time": 2808,
-    "total_elevation_gain": 169.6
+    "start_date": "2020-12-14T17:43:07Z",
+    "average_watts": 137.3,
+    "average_speed": 9.0,
+    "distance": 15993.5,
+    "moving_time": 1777,
+    "total_elevation_gain": 148.6,
+    "type": "Ride"
   },
   {
-    "start_date": "2025-04-28T17:08:40Z",
+    "start_date": "2020-12-15T11:34:55Z",
+    "average_watts": 145.7,
+    "average_speed": 8.517,
+    "distance": 14615.1,
+    "moving_time": 1716,
+    "total_elevation_gain": 114.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-20T09:28:16Z",
+    "average_watts": 135.6,
+    "average_speed": 5.453,
+    "distance": 50582.9,
+    "moving_time": 9277,
+    "total_elevation_gain": 331.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-21T15:13:15Z",
+    "average_watts": 145.6,
+    "average_speed": 6.958,
+    "distance": 66688.2,
+    "moving_time": 9585,
+    "total_elevation_gain": 757.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-22T15:43:48Z",
+    "average_watts": 164.2,
+    "average_speed": 5.735,
+    "distance": 58452.9,
+    "moving_time": 10193,
+    "total_elevation_gain": 635.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-24T06:53:39Z",
+    "average_watts": 168.8,
+    "average_speed": 6.989,
+    "distance": 50810.1,
+    "moving_time": 7270,
+    "total_elevation_gain": 456.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-25T14:49:03Z",
+    "average_watts": 171.2,
+    "average_speed": 5.151,
+    "distance": 86813.6,
+    "moving_time": 16854,
+    "total_elevation_gain": 804.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-26T15:30:02Z",
+    "average_watts": 138.0,
+    "average_speed": 4.168,
+    "distance": 5230.4,
+    "moving_time": 1255,
+    "total_elevation_gain": 50.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-29T07:42:54Z",
+    "average_watts": 140.0,
+    "average_speed": 6.375,
+    "distance": 54281.8,
+    "moving_time": 8515,
+    "total_elevation_gain": 347.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-30T19:24:22Z",
+    "average_watts": 133.5,
+    "average_speed": 5.576,
+    "distance": 20246.6,
+    "moving_time": 3631,
+    "total_elevation_gain": 242.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2020-12-31T16:18:52Z",
+    "average_watts": 152.0,
+    "average_speed": 5.616,
+    "distance": 26017.9,
+    "moving_time": 4633,
+    "total_elevation_gain": 234.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-01T19:15:58Z",
+    "average_watts": 154.6,
+    "average_speed": 6.568,
+    "distance": 55776.6,
+    "moving_time": 8492,
+    "total_elevation_gain": 804.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-02T09:29:15Z",
+    "average_watts": 160.8,
+    "average_speed": 3.75,
+    "distance": 4334.9,
+    "moving_time": 1156,
+    "total_elevation_gain": 59.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-03T12:42:29Z",
+    "average_watts": 141.6,
+    "average_speed": 5.107,
+    "distance": 39392.3,
+    "moving_time": 7714,
+    "total_elevation_gain": 481.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-07T13:42:20Z",
+    "average_watts": 157.8,
+    "average_speed": 6.998,
+    "distance": 94254.8,
+    "moving_time": 13468,
+    "total_elevation_gain": 944.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-08T16:09:34Z",
+    "average_watts": 172.5,
+    "average_speed": 6.473,
+    "distance": 60032.5,
+    "moving_time": 9274,
+    "total_elevation_gain": 719.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-12T09:22:44Z",
+    "average_watts": 151.4,
+    "average_speed": 5.309,
+    "distance": 4905.2,
+    "moving_time": 924,
+    "total_elevation_gain": 41.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-13T08:32:28Z",
+    "average_watts": 145.9,
+    "average_speed": 7.07,
+    "distance": 36602.3,
+    "moving_time": 5177,
+    "total_elevation_gain": 474.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-14T16:54:20Z",
+    "average_watts": 150.9,
+    "average_speed": 6.239,
+    "distance": 24325.9,
+    "moving_time": 3899,
+    "total_elevation_gain": 269.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-16T17:29:46Z",
+    "average_watts": 147.7,
+    "average_speed": 8.708,
+    "distance": 20899.4,
+    "moving_time": 2400,
+    "total_elevation_gain": 267.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-17T17:31:45Z",
+    "average_watts": 137.0,
+    "average_speed": 5.216,
+    "distance": 39302.0,
+    "moving_time": 7535,
+    "total_elevation_gain": 253.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-18T09:55:22Z",
+    "average_watts": 170.3,
+    "average_speed": 5.288,
+    "distance": 6218.5,
+    "moving_time": 1176,
+    "total_elevation_gain": 37.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-21T17:34:01Z",
+    "average_watts": 147.5,
+    "average_speed": 6.335,
+    "distance": 39919.7,
+    "moving_time": 6301,
+    "total_elevation_gain": 369.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-23T08:34:21Z",
+    "average_watts": 159.6,
+    "average_speed": 5.2,
+    "distance": 76697.3,
+    "moving_time": 14750,
+    "total_elevation_gain": 428.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-24T08:17:38Z",
+    "average_watts": 165.4,
+    "average_speed": 7.454,
+    "distance": 13789.1,
+    "moving_time": 1850,
+    "total_elevation_gain": 102.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-27T07:04:40Z",
+    "average_watts": 166.4,
+    "average_speed": 5.337,
+    "distance": 70646.3,
+    "moving_time": 13236,
+    "total_elevation_gain": 514.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-28T15:13:23Z",
+    "average_watts": 134.0,
+    "average_speed": 7.259,
+    "distance": 24854.3,
+    "moving_time": 3424,
+    "total_elevation_gain": 185.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-29T15:40:02Z",
+    "average_watts": 158.2,
+    "average_speed": 5.015,
+    "distance": 64355.5,
+    "moving_time": 12833,
+    "total_elevation_gain": 869.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-01-30T18:04:44Z",
+    "average_watts": 143.0,
+    "average_speed": 5.394,
+    "distance": 4007.4,
+    "moving_time": 743,
+    "total_elevation_gain": 29.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-06T16:12:48Z",
+    "average_watts": 165.9,
+    "average_speed": 9.868,
+    "distance": 21068.5,
+    "moving_time": 2135,
+    "total_elevation_gain": 286.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-09T09:13:17Z",
+    "average_watts": 138.6,
+    "average_speed": 7.892,
+    "distance": 20139.3,
+    "moving_time": 2552,
+    "total_elevation_gain": 213.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-11T06:31:47Z",
+    "average_watts": 145.7,
+    "average_speed": 5.013,
+    "distance": 7545.1,
+    "moving_time": 1505,
+    "total_elevation_gain": 97.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-14T13:20:55Z",
+    "average_watts": 138.6,
+    "average_speed": 8.911,
+    "distance": 18784.2,
+    "moving_time": 2108,
+    "total_elevation_gain": 272.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-15T06:03:17Z",
+    "average_watts": 154.8,
+    "average_speed": 8.749,
+    "distance": 11986.4,
+    "moving_time": 1370,
+    "total_elevation_gain": 98.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-16T14:32:04Z",
+    "average_watts": 154.5,
+    "average_speed": 6.63,
+    "distance": 74980.8,
+    "moving_time": 11310,
+    "total_elevation_gain": 1079.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-20T16:15:17Z",
+    "average_watts": 139.1,
+    "average_speed": 5.707,
+    "distance": 37835.3,
+    "moving_time": 6630,
+    "total_elevation_gain": 546.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-21T16:16:48Z",
+    "average_watts": 159.9,
+    "average_speed": 6.636,
+    "distance": 94428.6,
+    "moving_time": 14230,
+    "total_elevation_gain": 1379.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-22T12:42:35Z",
+    "average_watts": 162.7,
+    "average_speed": 7.287,
+    "distance": 24573.0,
+    "moving_time": 3372,
+    "total_elevation_gain": 227.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-25T19:52:14Z",
+    "average_watts": 158.2,
+    "average_speed": 3.892,
+    "distance": 6145.3,
+    "moving_time": 1579,
+    "total_elevation_gain": 46.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-02-26T14:44:42Z",
+    "average_watts": 156.9,
+    "average_speed": 5.424,
+    "distance": 4691.6,
+    "moving_time": 865,
+    "total_elevation_gain": 60.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-02T09:48:29Z",
+    "average_watts": 137.2,
+    "average_speed": 5.848,
+    "distance": 21603.4,
+    "moving_time": 3694,
+    "total_elevation_gain": 164.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-04T10:16:40Z",
+    "average_watts": 147.4,
+    "average_speed": 6.738,
+    "distance": 28650.6,
+    "moving_time": 4252,
+    "total_elevation_gain": 346.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-05T19:11:23Z",
+    "average_watts": 162.5,
+    "average_speed": 4.522,
+    "distance": 6367.6,
+    "moving_time": 1408,
+    "total_elevation_gain": 49.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-06T11:37:30Z",
+    "average_watts": 136.4,
+    "average_speed": 5.346,
+    "distance": 73836.3,
+    "moving_time": 13812,
+    "total_elevation_gain": 412.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-07T06:57:02Z",
+    "average_watts": 137.0,
+    "average_speed": 9.812,
+    "distance": 22057.7,
+    "moving_time": 2248,
+    "total_elevation_gain": 237.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-10T11:59:48Z",
+    "average_watts": 136.1,
+    "average_speed": 5.223,
+    "distance": 74641.4,
+    "moving_time": 14291,
+    "total_elevation_gain": 867.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-11T15:50:55Z",
+    "average_watts": 145.3,
+    "average_speed": 7.74,
+    "distance": 24248.2,
+    "moving_time": 3133,
+    "total_elevation_gain": 214.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-13T14:40:45Z",
+    "average_watts": 159.0,
+    "average_speed": 9.0,
+    "distance": 11168.8,
+    "moving_time": 1241,
+    "total_elevation_gain": 101.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-14T08:02:16Z",
+    "average_watts": 147.2,
+    "average_speed": 5.827,
+    "distance": 6094.8,
+    "moving_time": 1046,
+    "total_elevation_gain": 87.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-17T17:06:18Z",
+    "average_watts": 137.4,
+    "average_speed": 6.399,
+    "distance": 55707.7,
+    "moving_time": 8706,
+    "total_elevation_gain": 450.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-19T19:00:30Z",
+    "average_watts": 166.5,
+    "average_speed": 9.425,
+    "distance": 16673.2,
+    "moving_time": 1769,
+    "total_elevation_gain": 119.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-22T15:22:11Z",
+    "average_watts": 158.7,
+    "average_speed": 8.406,
+    "distance": 10120.7,
+    "moving_time": 1204,
+    "total_elevation_gain": 139.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-23T11:22:19Z",
+    "average_watts": 160.7,
+    "average_speed": 6.637,
+    "distance": 38060.8,
+    "moving_time": 5735,
+    "total_elevation_gain": 508.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-24T16:10:23Z",
+    "average_watts": 154.6,
+    "average_speed": 5.048,
+    "distance": 34233.0,
+    "moving_time": 6782,
+    "total_elevation_gain": 397.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-25T10:07:32Z",
+    "average_watts": 173.6,
+    "average_speed": 5.464,
+    "distance": 3513.1,
+    "moving_time": 643,
+    "total_elevation_gain": 47.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-27T06:44:24Z",
+    "average_watts": 174.3,
+    "average_speed": 5.526,
+    "distance": 67732.4,
+    "moving_time": 12257,
+    "total_elevation_gain": 454.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-03-30T17:20:54Z",
+    "average_watts": 141.2,
+    "average_speed": 5.98,
+    "distance": 55091.4,
+    "moving_time": 9213,
+    "total_elevation_gain": 680.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-03T08:54:15Z",
+    "average_watts": 147.9,
+    "average_speed": 5.17,
+    "distance": 4782.6,
+    "moving_time": 925,
+    "total_elevation_gain": 60.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-08T07:56:27Z",
+    "average_watts": 168.8,
+    "average_speed": 6.365,
+    "distance": 73097.9,
+    "moving_time": 11484,
+    "total_elevation_gain": 441.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-10T07:18:17Z",
+    "average_watts": 157.9,
+    "average_speed": 5.654,
+    "distance": 7452.0,
+    "moving_time": 1318,
+    "total_elevation_gain": 109.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-11T12:44:15Z",
+    "average_watts": 146.0,
+    "average_speed": 7.702,
+    "distance": 22814.5,
+    "moving_time": 2962,
+    "total_elevation_gain": 302.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-12T07:55:21Z",
+    "average_watts": 135.5,
+    "average_speed": 3.17,
+    "distance": 3858.0,
+    "moving_time": 1217,
+    "total_elevation_gain": 52.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-14T17:26:58Z",
+    "average_watts": 135.2,
+    "average_speed": 7.219,
+    "distance": 22790.9,
+    "moving_time": 3157,
+    "total_elevation_gain": 295.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-15T11:50:35Z",
+    "average_watts": 152.9,
+    "average_speed": 6.501,
+    "distance": 94724.3,
+    "moving_time": 14571,
+    "total_elevation_gain": 1027.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-16T06:46:43Z",
+    "average_watts": 142.8,
+    "average_speed": 4.467,
+    "distance": 6383.1,
+    "moving_time": 1429,
+    "total_elevation_gain": 68.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-18T08:24:45Z",
+    "average_watts": 156.9,
+    "average_speed": 6.896,
+    "distance": 36355.1,
+    "moving_time": 5272,
+    "total_elevation_gain": 393.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-19T18:00:13Z",
+    "average_watts": 170.8,
+    "average_speed": 7.654,
+    "distance": 21935.2,
+    "moving_time": 2866,
+    "total_elevation_gain": 145.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-27T17:11:08Z",
+    "average_watts": 145.4,
+    "average_speed": 6.484,
+    "distance": 74377.2,
+    "moving_time": 11470,
+    "total_elevation_gain": 531.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-28T07:03:01Z",
+    "average_watts": 172.2,
+    "average_speed": 4.755,
+    "distance": 7375.3,
+    "moving_time": 1551,
+    "total_elevation_gain": 50.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-29T15:28:20Z",
+    "average_watts": 143.4,
+    "average_speed": 6.634,
+    "distance": 63144.3,
+    "moving_time": 9518,
+    "total_elevation_gain": 587.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-04-30T16:14:40Z",
+    "average_watts": 135.2,
+    "average_speed": 9.522,
+    "distance": 23509.2,
+    "moving_time": 2469,
+    "total_elevation_gain": 243.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-02T10:18:56Z",
+    "average_watts": 159.7,
+    "average_speed": 6.351,
+    "distance": 77647.8,
+    "moving_time": 12227,
+    "total_elevation_gain": 562.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-03T16:50:01Z",
+    "average_watts": 155.3,
+    "average_speed": 7.686,
+    "distance": 26364.5,
+    "moving_time": 3430,
+    "total_elevation_gain": 345.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-06T10:36:46Z",
+    "average_watts": 161.3,
+    "average_speed": 5.654,
+    "distance": 82150.2,
+    "moving_time": 14530,
+    "total_elevation_gain": 1042.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-08T13:39:45Z",
+    "average_watts": 146.1,
+    "average_speed": 5.219,
+    "distance": 7499.2,
+    "moving_time": 1437,
+    "total_elevation_gain": 74.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-09T08:41:48Z",
+    "average_watts": 160.2,
+    "average_speed": 7.403,
+    "distance": 34703.1,
+    "moving_time": 4688,
+    "total_elevation_gain": 391.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-10T07:57:03Z",
+    "average_watts": 162.6,
+    "average_speed": 3.353,
+    "distance": 6360.6,
+    "moving_time": 1897,
+    "total_elevation_gain": 57.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-11T18:29:25Z",
+    "average_watts": 162.5,
+    "average_speed": 5.092,
+    "distance": 87641.6,
+    "moving_time": 17213,
+    "total_elevation_gain": 469.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-13T11:45:58Z",
+    "average_watts": 167.3,
+    "average_speed": 5.98,
+    "distance": 61687.7,
+    "moving_time": 10315,
+    "total_elevation_gain": 810.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-16T11:32:15Z",
+    "average_watts": 164.6,
+    "average_speed": 7.124,
+    "distance": 12268.2,
+    "moving_time": 1722,
+    "total_elevation_gain": 120.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-17T12:29:42Z",
+    "average_watts": 170.4,
+    "average_speed": 6.329,
+    "distance": 92655.8,
+    "moving_time": 14639,
+    "total_elevation_gain": 497.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-19T07:57:26Z",
+    "average_watts": 166.9,
+    "average_speed": 9.319,
+    "distance": 12944.0,
+    "moving_time": 1389,
+    "total_elevation_gain": 192.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-23T08:35:45Z",
+    "average_watts": 160.2,
+    "average_speed": 5.496,
+    "distance": 23875.9,
+    "moving_time": 4344,
+    "total_elevation_gain": 301.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-25T16:40:21Z",
+    "average_watts": 140.2,
+    "average_speed": 9.076,
+    "distance": 21573.1,
+    "moving_time": 2377,
+    "total_elevation_gain": 165.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-26T06:53:31Z",
+    "average_watts": 139.8,
+    "average_speed": 5.353,
+    "distance": 61584.4,
+    "moving_time": 11504,
+    "total_elevation_gain": 863.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-29T18:36:34Z",
+    "average_watts": 139.2,
+    "average_speed": 6.995,
+    "distance": 56726.5,
+    "moving_time": 8110,
+    "total_elevation_gain": 300.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-05-30T08:42:28Z",
+    "average_watts": 169.0,
+    "average_speed": 6.291,
+    "distance": 88639.9,
+    "moving_time": 14090,
+    "total_elevation_gain": 740.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-01T09:20:04Z",
+    "average_watts": 167.7,
+    "average_speed": 8.216,
+    "distance": 11149.2,
+    "moving_time": 1357,
+    "total_elevation_gain": 129.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-03T16:43:40Z",
+    "average_watts": 168.5,
+    "average_speed": 6.002,
+    "distance": 67844.7,
+    "moving_time": 11303,
+    "total_elevation_gain": 610.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-04T15:44:52Z",
+    "average_watts": 139.9,
+    "average_speed": 7.249,
+    "distance": 39657.9,
+    "moving_time": 5471,
+    "total_elevation_gain": 581.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-05T14:53:06Z",
+    "average_watts": 154.9,
+    "average_speed": 5.292,
+    "distance": 3873.9,
+    "moving_time": 732,
+    "total_elevation_gain": 50.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-06T08:56:35Z",
+    "average_watts": 170.2,
+    "average_speed": 7.949,
+    "distance": 18585.1,
+    "moving_time": 2338,
+    "total_elevation_gain": 204.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-07T19:34:38Z",
+    "average_watts": 152.7,
+    "average_speed": 6.291,
+    "distance": 94703.5,
+    "moving_time": 15055,
+    "total_elevation_gain": 940.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-10T08:56:33Z",
+    "average_watts": 165.4,
+    "average_speed": 3.587,
+    "distance": 3329.2,
+    "moving_time": 928,
+    "total_elevation_gain": 41.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-15T10:15:40Z",
+    "average_watts": 156.1,
+    "average_speed": 6.956,
+    "distance": 36750.9,
+    "moving_time": 5283,
+    "total_elevation_gain": 503.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-17T15:57:22Z",
+    "average_watts": 159.6,
+    "average_speed": 7.859,
+    "distance": 14735.4,
+    "moving_time": 1875,
+    "total_elevation_gain": 128.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-18T18:44:02Z",
+    "average_watts": 142.1,
+    "average_speed": 9.286,
+    "distance": 13901.4,
+    "moving_time": 1497,
+    "total_elevation_gain": 83.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-20T18:28:47Z",
+    "average_watts": 144.8,
+    "average_speed": 3.024,
+    "distance": 4548.0,
+    "moving_time": 1504,
+    "total_elevation_gain": 34.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-23T13:04:31Z",
+    "average_watts": 173.1,
+    "average_speed": 5.334,
+    "distance": 88081.9,
+    "moving_time": 16514,
+    "total_elevation_gain": 454.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-26T16:49:05Z",
+    "average_watts": 157.4,
+    "average_speed": 5.53,
+    "distance": 52847.6,
+    "moving_time": 9557,
+    "total_elevation_gain": 270.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-28T10:30:20Z",
+    "average_watts": 148.1,
+    "average_speed": 6.642,
+    "distance": 52128.8,
+    "moving_time": 7848,
+    "total_elevation_gain": 547.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-06-30T16:31:54Z",
+    "average_watts": 144.8,
+    "average_speed": 7.831,
+    "distance": 36938.2,
+    "moving_time": 4717,
+    "total_elevation_gain": 215.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-03T10:52:26Z",
+    "average_watts": 174.8,
+    "average_speed": 6.746,
+    "distance": 31761.4,
+    "moving_time": 4708,
+    "total_elevation_gain": 195.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-06T15:30:33Z",
+    "average_watts": 169.6,
+    "average_speed": 3.996,
+    "distance": 4794.7,
+    "moving_time": 1200,
+    "total_elevation_gain": 28.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-07T18:28:01Z",
+    "average_watts": 165.7,
+    "average_speed": 5.549,
+    "distance": 51593.6,
+    "moving_time": 9298,
+    "total_elevation_gain": 500.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-09T14:56:25Z",
+    "average_watts": 159.2,
+    "average_speed": 5.83,
+    "distance": 87148.2,
+    "moving_time": 14948,
+    "total_elevation_gain": 650.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-10T16:04:26Z",
+    "average_watts": 175.3,
+    "average_speed": 5.858,
+    "distance": 92645.1,
+    "moving_time": 15814,
+    "total_elevation_gain": 737.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-12T18:36:56Z",
+    "average_watts": 163.0,
+    "average_speed": 8.736,
+    "distance": 15139.0,
+    "moving_time": 1733,
+    "total_elevation_gain": 136.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-14T10:31:37Z",
+    "average_watts": 149.8,
+    "average_speed": 5.483,
+    "distance": 94677.3,
+    "moving_time": 17269,
+    "total_elevation_gain": 1382.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-27T10:49:06Z",
+    "average_watts": 168.4,
+    "average_speed": 3.673,
+    "distance": 5678.2,
+    "moving_time": 1546,
+    "total_elevation_gain": 58.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-07-28T09:14:40Z",
+    "average_watts": 157.9,
+    "average_speed": 9.386,
+    "distance": 18660.3,
+    "moving_time": 1988,
+    "total_elevation_gain": 278.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-01T11:31:53Z",
+    "average_watts": 157.3,
+    "average_speed": 6.371,
+    "distance": 81448.9,
+    "moving_time": 12785,
+    "total_elevation_gain": 909.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-02T19:04:40Z",
+    "average_watts": 173.3,
+    "average_speed": 3.687,
+    "distance": 6401.2,
+    "moving_time": 1736,
+    "total_elevation_gain": 93.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-07T13:30:53Z",
+    "average_watts": 157.4,
+    "average_speed": 4.226,
+    "distance": 7252.2,
+    "moving_time": 1716,
+    "total_elevation_gain": 94.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-09T06:03:54Z",
+    "average_watts": 170.6,
+    "average_speed": 6.014,
+    "distance": 71194.9,
+    "moving_time": 11839,
+    "total_elevation_gain": 912.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-11T08:13:38Z",
+    "average_watts": 151.6,
+    "average_speed": 5.468,
+    "distance": 3116.8,
+    "moving_time": 570,
+    "total_elevation_gain": 22.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-12T15:43:07Z",
+    "average_watts": 140.1,
+    "average_speed": 8.935,
+    "distance": 23705.3,
+    "moving_time": 2653,
+    "total_elevation_gain": 168.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-13T16:30:57Z",
+    "average_watts": 173.4,
+    "average_speed": 8.344,
+    "distance": 15119.3,
+    "moving_time": 1812,
+    "total_elevation_gain": 82.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-14T09:19:37Z",
+    "average_watts": 152.4,
+    "average_speed": 3.1,
+    "distance": 3373.0,
+    "moving_time": 1088,
+    "total_elevation_gain": 29.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-16T15:30:15Z",
+    "average_watts": 145.8,
+    "average_speed": 5.318,
+    "distance": 50604.1,
+    "moving_time": 9515,
+    "total_elevation_gain": 362.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-18T15:49:46Z",
+    "average_watts": 140.4,
+    "average_speed": 5.327,
+    "distance": 36317.1,
+    "moving_time": 6817,
+    "total_elevation_gain": 431.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-19T10:15:01Z",
+    "average_watts": 142.0,
+    "average_speed": 6.288,
+    "distance": 28734.3,
+    "moving_time": 4570,
+    "total_elevation_gain": 270.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-20T06:17:24Z",
+    "average_watts": 156.2,
+    "average_speed": 9.64,
+    "distance": 22008.0,
+    "moving_time": 2283,
+    "total_elevation_gain": 229.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-21T15:14:20Z",
+    "average_watts": 165.7,
+    "average_speed": 7.524,
+    "distance": 16560.7,
+    "moving_time": 2201,
+    "total_elevation_gain": 240.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-26T18:32:39Z",
+    "average_watts": 147.3,
+    "average_speed": 5.566,
+    "distance": 5984.0,
+    "moving_time": 1075,
+    "total_elevation_gain": 50.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-27T18:00:08Z",
+    "average_watts": 163.1,
+    "average_speed": 7.082,
+    "distance": 29871.8,
+    "moving_time": 4218,
+    "total_elevation_gain": 382.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-29T09:43:10Z",
+    "average_watts": 165.8,
+    "average_speed": 3.57,
+    "distance": 5362.7,
+    "moving_time": 1502,
+    "total_elevation_gain": 36.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-08-31T06:53:52Z",
+    "average_watts": 163.1,
+    "average_speed": 7.324,
+    "distance": 26306.1,
+    "moving_time": 3592,
+    "total_elevation_gain": 265.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-01T11:39:42Z",
+    "average_watts": 159.8,
+    "average_speed": 9.02,
+    "distance": 20087.0,
+    "moving_time": 2227,
+    "total_elevation_gain": 216.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-02T09:38:36Z",
+    "average_watts": 170.9,
+    "average_speed": 6.336,
+    "distance": 75490.9,
+    "moving_time": 11915,
+    "total_elevation_gain": 983.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-04T15:47:58Z",
+    "average_watts": 176.7,
+    "average_speed": 6.609,
+    "distance": 89111.9,
+    "moving_time": 13483,
+    "total_elevation_gain": 1281.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-06T11:52:09Z",
+    "average_watts": 151.6,
+    "average_speed": 9.958,
+    "distance": 10147.4,
+    "moving_time": 1019,
+    "total_elevation_gain": 151.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-08T07:41:04Z",
+    "average_watts": 139.5,
+    "average_speed": 6.096,
+    "distance": 60214.9,
+    "moving_time": 9878,
+    "total_elevation_gain": 338.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-09T17:53:29Z",
+    "average_watts": 144.5,
+    "average_speed": 3.644,
+    "distance": 6504.0,
+    "moving_time": 1785,
+    "total_elevation_gain": 43.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-10T14:46:33Z",
+    "average_watts": 147.5,
+    "average_speed": 7.324,
+    "distance": 28892.9,
+    "moving_time": 3945,
+    "total_elevation_gain": 175.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-11T09:05:40Z",
+    "average_watts": 154.2,
+    "average_speed": 3.522,
+    "distance": 4528.9,
+    "moving_time": 1286,
+    "total_elevation_gain": 24.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-13T10:23:01Z",
+    "average_watts": 150.1,
+    "average_speed": 6.585,
+    "distance": 98365.2,
+    "moving_time": 14938,
+    "total_elevation_gain": 1309.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-14T16:48:23Z",
+    "average_watts": 159.6,
+    "average_speed": 7.06,
+    "distance": 21541.0,
+    "moving_time": 3051,
+    "total_elevation_gain": 314.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-15T08:44:36Z",
+    "average_watts": 167.7,
+    "average_speed": 5.448,
+    "distance": 96579.0,
+    "moving_time": 17727,
+    "total_elevation_gain": 1252.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-17T17:10:19Z",
+    "average_watts": 172.7,
+    "average_speed": 3.271,
+    "distance": 5995.1,
+    "moving_time": 1833,
+    "total_elevation_gain": 59.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-19T17:07:11Z",
+    "average_watts": 151.0,
+    "average_speed": 5.222,
+    "distance": 5520.0,
+    "moving_time": 1057,
+    "total_elevation_gain": 32.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-23T09:14:04Z",
+    "average_watts": 150.6,
+    "average_speed": 5.212,
+    "distance": 7859.8,
+    "moving_time": 1508,
+    "total_elevation_gain": 83.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-24T18:56:01Z",
+    "average_watts": 175.6,
+    "average_speed": 8.421,
+    "distance": 13447.7,
+    "moving_time": 1597,
+    "total_elevation_gain": 120.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-25T11:38:56Z",
+    "average_watts": 150.1,
+    "average_speed": 7.122,
+    "distance": 23475.3,
+    "moving_time": 3296,
+    "total_elevation_gain": 326.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-27T19:51:30Z",
+    "average_watts": 140.6,
+    "average_speed": 6.136,
+    "distance": 34281.4,
+    "moving_time": 5587,
+    "total_elevation_gain": 500.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-29T07:38:48Z",
+    "average_watts": 148.0,
+    "average_speed": 5.476,
+    "distance": 31236.6,
+    "moving_time": 5704,
+    "total_elevation_gain": 457.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-09-30T16:28:28Z",
+    "average_watts": 168.9,
+    "average_speed": 7.872,
+    "distance": 18326.7,
+    "moving_time": 2328,
+    "total_elevation_gain": 190.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-01T19:21:59Z",
+    "average_watts": 169.8,
+    "average_speed": 4.153,
+    "distance": 6981.2,
+    "moving_time": 1681,
+    "total_elevation_gain": 62.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-02T15:43:21Z",
+    "average_watts": 148.1,
+    "average_speed": 7.947,
+    "distance": 20305.1,
+    "moving_time": 2555,
+    "total_elevation_gain": 219.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-05T13:20:41Z",
+    "average_watts": 145.8,
+    "average_speed": 8.114,
+    "distance": 23854.4,
+    "moving_time": 2940,
+    "total_elevation_gain": 176.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-07T06:00:17Z",
+    "average_watts": 143.4,
+    "average_speed": 5.241,
+    "distance": 77969.1,
+    "moving_time": 14877,
+    "total_elevation_gain": 1001.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-08T13:54:06Z",
+    "average_watts": 169.9,
+    "average_speed": 6.917,
+    "distance": 91423.5,
+    "moving_time": 13218,
+    "total_elevation_gain": 867.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-13T11:35:07Z",
+    "average_watts": 152.6,
+    "average_speed": 6.469,
+    "distance": 35751.6,
+    "moving_time": 5527,
+    "total_elevation_gain": 273.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-14T15:55:18Z",
+    "average_watts": 137.4,
+    "average_speed": 9.727,
+    "distance": 13832.1,
+    "moving_time": 1422,
+    "total_elevation_gain": 158.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-16T17:59:05Z",
+    "average_watts": 175.2,
+    "average_speed": 5.397,
+    "distance": 21151.7,
+    "moving_time": 3919,
+    "total_elevation_gain": 122.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-19T09:10:42Z",
+    "average_watts": 165.2,
+    "average_speed": 5.105,
+    "distance": 63796.2,
+    "moving_time": 12496,
+    "total_elevation_gain": 768.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-20T11:50:01Z",
+    "average_watts": 152.0,
+    "average_speed": 6.155,
+    "distance": 94364.0,
+    "moving_time": 15332,
+    "total_elevation_gain": 629.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-22T13:22:53Z",
+    "average_watts": 167.4,
+    "average_speed": 8.023,
+    "distance": 13285.6,
+    "moving_time": 1656,
+    "total_elevation_gain": 158.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-23T13:04:52Z",
+    "average_watts": 166.9,
+    "average_speed": 4.63,
+    "distance": 3204.1,
+    "moving_time": 692,
+    "total_elevation_gain": 37.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-29T07:37:06Z",
+    "average_watts": 161.0,
+    "average_speed": 6.001,
+    "distance": 6804.6,
+    "moving_time": 1134,
+    "total_elevation_gain": 39.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-10-30T08:22:24Z",
+    "average_watts": 168.8,
+    "average_speed": 5.531,
+    "distance": 78250.2,
+    "moving_time": 14148,
+    "total_elevation_gain": 1085.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-02T07:51:26Z",
+    "average_watts": 144.7,
+    "average_speed": 3.629,
+    "distance": 7061.9,
+    "moving_time": 1946,
+    "total_elevation_gain": 83.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-06T12:21:30Z",
+    "average_watts": 169.4,
+    "average_speed": 6.431,
+    "distance": 21255.4,
+    "moving_time": 3305,
+    "total_elevation_gain": 220.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-08T13:32:12Z",
+    "average_watts": 158.8,
+    "average_speed": 5.627,
+    "distance": 3674.5,
+    "moving_time": 653,
+    "total_elevation_gain": 51.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-09T19:06:44Z",
+    "average_watts": 157.5,
+    "average_speed": 6.672,
+    "distance": 69624.3,
+    "moving_time": 10436,
+    "total_elevation_gain": 578.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-10T11:55:45Z",
+    "average_watts": 150.7,
+    "average_speed": 5.036,
+    "distance": 94045.6,
+    "moving_time": 18674,
+    "total_elevation_gain": 697.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-11T18:07:07Z",
+    "average_watts": 172.5,
+    "average_speed": 7.485,
+    "distance": 31676.7,
+    "moving_time": 4232,
+    "total_elevation_gain": 395.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-12T12:13:52Z",
+    "average_watts": 150.3,
+    "average_speed": 7.122,
+    "distance": 27575.5,
+    "moving_time": 3872,
+    "total_elevation_gain": 246.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-15T14:34:24Z",
+    "average_watts": 151.3,
+    "average_speed": 5.755,
+    "distance": 35292.8,
+    "moving_time": 6133,
+    "total_elevation_gain": 294.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-16T14:54:09Z",
+    "average_watts": 169.1,
+    "average_speed": 5.344,
+    "distance": 38602.0,
+    "moving_time": 7223,
+    "total_elevation_gain": 359.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-18T18:17:05Z",
+    "average_watts": 170.4,
+    "average_speed": 6.026,
+    "distance": 94311.6,
+    "moving_time": 15652,
+    "total_elevation_gain": 742.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-19T11:17:14Z",
+    "average_watts": 165.7,
+    "average_speed": 5.12,
+    "distance": 4684.4,
+    "moving_time": 915,
+    "total_elevation_gain": 65.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-20T12:15:49Z",
+    "average_watts": 152.8,
+    "average_speed": 5.563,
+    "distance": 74189.5,
+    "moving_time": 13337,
+    "total_elevation_gain": 643.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-21T18:39:12Z",
+    "average_watts": 141.3,
+    "average_speed": 9.465,
+    "distance": 20500.6,
+    "moving_time": 2166,
+    "total_elevation_gain": 204.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-23T09:22:11Z",
+    "average_watts": 165.8,
+    "average_speed": 5.802,
+    "distance": 33506.3,
+    "moving_time": 5775,
+    "total_elevation_gain": 341.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-24T14:10:48Z",
+    "average_watts": 155.8,
+    "average_speed": 8.643,
+    "distance": 22118.6,
+    "moving_time": 2559,
+    "total_elevation_gain": 227.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-26T08:20:32Z",
+    "average_watts": 141.9,
+    "average_speed": 5.065,
+    "distance": 35989.4,
+    "moving_time": 7105,
+    "total_elevation_gain": 294.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-11-30T18:16:16Z",
+    "average_watts": 145.0,
+    "average_speed": 7.727,
+    "distance": 10455.1,
+    "moving_time": 1353,
+    "total_elevation_gain": 93.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-01T09:39:03Z",
+    "average_watts": 165.9,
+    "average_speed": 8.498,
+    "distance": 11379.2,
+    "moving_time": 1339,
+    "total_elevation_gain": 74.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-04T13:33:43Z",
+    "average_watts": 157.9,
+    "average_speed": 5.992,
+    "distance": 64666.2,
+    "moving_time": 10792,
+    "total_elevation_gain": 904.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-05T17:04:50Z",
+    "average_watts": 148.5,
+    "average_speed": 8.145,
+    "distance": 19263.3,
+    "moving_time": 2365,
+    "total_elevation_gain": 104.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-06T11:31:43Z",
+    "average_watts": 169.5,
+    "average_speed": 5.194,
+    "distance": 95819.8,
+    "moving_time": 18447,
+    "total_elevation_gain": 1286.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-07T09:12:54Z",
+    "average_watts": 139.2,
+    "average_speed": 5.887,
+    "distance": 7082.5,
+    "moving_time": 1203,
+    "total_elevation_gain": 65.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-08T10:39:02Z",
+    "average_watts": 161.2,
+    "average_speed": 6.212,
+    "distance": 53307.9,
+    "moving_time": 8582,
+    "total_elevation_gain": 518.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-09T13:35:33Z",
+    "average_watts": 152.5,
+    "average_speed": 5.41,
+    "distance": 21741.1,
+    "moving_time": 4019,
+    "total_elevation_gain": 273.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-10T11:12:17Z",
+    "average_watts": 167.4,
+    "average_speed": 5.68,
+    "distance": 79882.3,
+    "moving_time": 14063,
+    "total_elevation_gain": 650.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-11T09:55:11Z",
+    "average_watts": 139.5,
+    "average_speed": 4.593,
+    "distance": 5557.5,
+    "moving_time": 1210,
+    "total_elevation_gain": 76.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-12T06:24:36Z",
+    "average_watts": 166.3,
+    "average_speed": 6.922,
+    "distance": 69221.3,
+    "moving_time": 10000,
+    "total_elevation_gain": 973.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-13T18:13:28Z",
+    "average_watts": 177.9,
+    "average_speed": 6.416,
+    "distance": 91995.7,
+    "moving_time": 14338,
+    "total_elevation_gain": 1233.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-14T10:21:21Z",
+    "average_watts": 174.3,
+    "average_speed": 6.356,
+    "distance": 77557.8,
+    "moving_time": 12203,
+    "total_elevation_gain": 1002.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-17T13:02:19Z",
+    "average_watts": 150.6,
+    "average_speed": 7.518,
+    "distance": 15066.1,
+    "moving_time": 2004,
+    "total_elevation_gain": 163.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-21T11:44:59Z",
+    "average_watts": 164.3,
+    "average_speed": 5.203,
+    "distance": 76041.4,
+    "moving_time": 14616,
+    "total_elevation_gain": 1068.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-23T12:53:27Z",
+    "average_watts": 145.2,
+    "average_speed": 7.994,
+    "distance": 10887.3,
+    "moving_time": 1362,
+    "total_elevation_gain": 87.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-24T08:44:29Z",
+    "average_watts": 155.9,
+    "average_speed": 6.477,
+    "distance": 36874.0,
+    "moving_time": 5693,
+    "total_elevation_gain": 388.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-28T09:33:52Z",
+    "average_watts": 140.6,
+    "average_speed": 4.46,
+    "distance": 3451.8,
+    "moving_time": 774,
+    "total_elevation_gain": 19.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2021-12-31T12:46:24Z",
+    "average_watts": 165.3,
+    "average_speed": 5.903,
+    "distance": 96287.9,
+    "moving_time": 16311,
+    "total_elevation_gain": 855.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-03T17:00:09Z",
+    "average_watts": 159.2,
+    "average_speed": 7.711,
+    "distance": 15460.8,
+    "moving_time": 2005,
+    "total_elevation_gain": 110.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-05T19:55:04Z",
+    "average_watts": 164.7,
+    "average_speed": 6.806,
+    "distance": 89055.7,
+    "moving_time": 13084,
+    "total_elevation_gain": 1091.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-11T14:55:14Z",
+    "average_watts": 168.2,
+    "average_speed": 5.03,
+    "distance": 37968.8,
+    "moving_time": 7548,
+    "total_elevation_gain": 475.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-13T12:14:50Z",
+    "average_watts": 172.4,
+    "average_speed": 9.864,
+    "distance": 10238.5,
+    "moving_time": 1038,
+    "total_elevation_gain": 60.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-15T08:41:30Z",
+    "average_watts": 152.0,
+    "average_speed": 9.278,
+    "distance": 16096.9,
+    "moving_time": 1735,
+    "total_elevation_gain": 216.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-18T19:41:26Z",
+    "average_watts": 149.0,
+    "average_speed": 6.001,
+    "distance": 92475.5,
+    "moving_time": 15411,
+    "total_elevation_gain": 969.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-21T13:23:44Z",
+    "average_watts": 172.1,
+    "average_speed": 6.926,
+    "distance": 86021.5,
+    "moving_time": 12420,
+    "total_elevation_gain": 1111.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-22T07:28:47Z",
+    "average_watts": 151.0,
+    "average_speed": 7.613,
+    "distance": 18475.9,
+    "moving_time": 2427,
+    "total_elevation_gain": 159.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-25T15:10:23Z",
+    "average_watts": 143.8,
+    "average_speed": 7.315,
+    "distance": 29984.6,
+    "moving_time": 4099,
+    "total_elevation_gain": 384.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-26T09:07:29Z",
+    "average_watts": 147.0,
+    "average_speed": 5.861,
+    "distance": 27799.5,
+    "moving_time": 4743,
+    "total_elevation_gain": 222.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-27T18:21:41Z",
+    "average_watts": 172.4,
+    "average_speed": 5.245,
+    "distance": 5496.8,
+    "moving_time": 1048,
+    "total_elevation_gain": 42.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-01-28T13:57:30Z",
+    "average_watts": 174.6,
+    "average_speed": 7.09,
+    "distance": 16590.7,
+    "moving_time": 2340,
+    "total_elevation_gain": 223.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-03T16:03:20Z",
+    "average_watts": 145.1,
+    "average_speed": 5.927,
+    "distance": 7805.9,
+    "moving_time": 1317,
+    "total_elevation_gain": 99.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-06T08:27:12Z",
+    "average_watts": 160.9,
+    "average_speed": 4.575,
+    "distance": 4391.9,
+    "moving_time": 960,
+    "total_elevation_gain": 34.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-07T08:33:12Z",
+    "average_watts": 154.1,
+    "average_speed": 6.727,
+    "distance": 23799.6,
+    "moving_time": 3538,
+    "total_elevation_gain": 317.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-08T16:36:56Z",
+    "average_watts": 140.3,
+    "average_speed": 4.869,
+    "distance": 6836.1,
+    "moving_time": 1404,
+    "total_elevation_gain": 91.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-09T06:52:43Z",
+    "average_watts": 158.2,
+    "average_speed": 5.784,
+    "distance": 89246.6,
+    "moving_time": 15429,
+    "total_elevation_gain": 999.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-12T10:37:00Z",
+    "average_watts": 159.1,
+    "average_speed": 8.954,
+    "distance": 24516.8,
+    "moving_time": 2738,
+    "total_elevation_gain": 285.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-13T10:01:46Z",
+    "average_watts": 178.6,
+    "average_speed": 5.431,
+    "distance": 4844.9,
+    "moving_time": 892,
+    "total_elevation_gain": 45.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-17T08:15:58Z",
+    "average_watts": 166.1,
+    "average_speed": 5.816,
+    "distance": 81050.2,
+    "moving_time": 13935,
+    "total_elevation_gain": 464.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-19T19:05:29Z",
+    "average_watts": 156.7,
+    "average_speed": 9.643,
+    "distance": 12516.2,
+    "moving_time": 1298,
+    "total_elevation_gain": 81.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-21T07:08:30Z",
+    "average_watts": 149.4,
+    "average_speed": 5.839,
+    "distance": 7468.3,
+    "moving_time": 1279,
+    "total_elevation_gain": 106.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-24T14:56:59Z",
+    "average_watts": 176.2,
+    "average_speed": 6.885,
+    "distance": 33745.5,
+    "moving_time": 4901,
+    "total_elevation_gain": 368.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-25T13:24:44Z",
+    "average_watts": 164.8,
+    "average_speed": 4.112,
+    "distance": 3527.9,
+    "moving_time": 858,
+    "total_elevation_gain": 30.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-02-28T13:30:37Z",
+    "average_watts": 163.6,
+    "average_speed": 5.281,
+    "distance": 4066.1,
+    "moving_time": 770,
+    "total_elevation_gain": 59.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-05T13:24:58Z",
+    "average_watts": 159.5,
+    "average_speed": 3.505,
+    "distance": 7690.2,
+    "moving_time": 2194,
+    "total_elevation_gain": 53.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-07T16:39:49Z",
+    "average_watts": 177.9,
+    "average_speed": 5.247,
+    "distance": 31223.4,
+    "moving_time": 5951,
+    "total_elevation_gain": 176.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-11T17:29:20Z",
+    "average_watts": 162.5,
+    "average_speed": 6.445,
+    "distance": 29841.5,
+    "moving_time": 4630,
+    "total_elevation_gain": 266.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-12T06:11:47Z",
+    "average_watts": 158.7,
+    "average_speed": 4.167,
+    "distance": 4492.5,
+    "moving_time": 1078,
+    "total_elevation_gain": 52.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-15T19:20:16Z",
+    "average_watts": 175.2,
+    "average_speed": 5.468,
+    "distance": 83807.4,
+    "moving_time": 15326,
+    "total_elevation_gain": 1099.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-16T15:54:31Z",
+    "average_watts": 152.5,
+    "average_speed": 5.016,
+    "distance": 31169.6,
+    "moving_time": 6214,
+    "total_elevation_gain": 280.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-19T16:30:57Z",
+    "average_watts": 155.4,
+    "average_speed": 7.913,
+    "distance": 21601.3,
+    "moving_time": 2730,
+    "total_elevation_gain": 202.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-22T15:09:15Z",
+    "average_watts": 173.2,
+    "average_speed": 8.524,
+    "distance": 20252.6,
+    "moving_time": 2376,
+    "total_elevation_gain": 291.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-24T09:05:32Z",
+    "average_watts": 148.0,
+    "average_speed": 3.196,
+    "distance": 3502.4,
+    "moving_time": 1096,
+    "total_elevation_gain": 33.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-25T15:09:46Z",
+    "average_watts": 177.8,
+    "average_speed": 8.067,
+    "distance": 10286.0,
+    "moving_time": 1275,
+    "total_elevation_gain": 52.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-26T10:19:48Z",
+    "average_watts": 146.5,
+    "average_speed": 6.98,
+    "distance": 93873.1,
+    "moving_time": 13448,
+    "total_elevation_gain": 1379.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-27T06:34:30Z",
+    "average_watts": 152.7,
+    "average_speed": 9.391,
+    "distance": 17712.2,
+    "moving_time": 1886,
+    "total_elevation_gain": 93.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-29T18:34:23Z",
+    "average_watts": 161.8,
+    "average_speed": 5.681,
+    "distance": 4368.5,
+    "moving_time": 769,
+    "total_elevation_gain": 61.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-03-30T15:59:38Z",
+    "average_watts": 165.9,
+    "average_speed": 5.345,
+    "distance": 68345.0,
+    "moving_time": 12786,
+    "total_elevation_gain": 558.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-01T10:22:06Z",
+    "average_watts": 175.9,
+    "average_speed": 3.057,
+    "distance": 7293.7,
+    "moving_time": 2386,
+    "total_elevation_gain": 60.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-05T09:09:56Z",
+    "average_watts": 146.3,
+    "average_speed": 5.597,
+    "distance": 52658.7,
+    "moving_time": 9409,
+    "total_elevation_gain": 516.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-06T11:07:31Z",
+    "average_watts": 145.5,
+    "average_speed": 8.227,
+    "distance": 12529.7,
+    "moving_time": 1523,
+    "total_elevation_gain": 104.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-09T12:36:14Z",
+    "average_watts": 179.0,
+    "average_speed": 5.348,
+    "distance": 92507.1,
+    "moving_time": 17298,
+    "total_elevation_gain": 906.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-10T06:44:08Z",
+    "average_watts": 174.7,
+    "average_speed": 5.594,
+    "distance": 71457.1,
+    "moving_time": 12773,
+    "total_elevation_gain": 630.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-11T12:50:14Z",
+    "average_watts": 167.6,
+    "average_speed": 10.001,
+    "distance": 10931.1,
+    "moving_time": 1093,
+    "total_elevation_gain": 159.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-12T19:47:11Z",
+    "average_watts": 157.1,
+    "average_speed": 6.145,
+    "distance": 85004.6,
+    "moving_time": 13834,
+    "total_elevation_gain": 947.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-13T09:02:04Z",
+    "average_watts": 164.7,
+    "average_speed": 5.344,
+    "distance": 66107.1,
+    "moving_time": 12370,
+    "total_elevation_gain": 735.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-14T15:48:45Z",
+    "average_watts": 145.2,
+    "average_speed": 5.346,
+    "distance": 37829.4,
+    "moving_time": 7076,
+    "total_elevation_gain": 404.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-15T17:56:22Z",
+    "average_watts": 173.7,
+    "average_speed": 7.998,
+    "distance": 39982.9,
+    "moving_time": 4999,
+    "total_elevation_gain": 257.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-18T19:50:32Z",
+    "average_watts": 169.3,
+    "average_speed": 3.284,
+    "distance": 4502.6,
+    "moving_time": 1371,
+    "total_elevation_gain": 61.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-19T16:57:19Z",
+    "average_watts": 141.2,
+    "average_speed": 9.939,
+    "distance": 19232.3,
+    "moving_time": 1935,
+    "total_elevation_gain": 253.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-20T09:29:40Z",
+    "average_watts": 145.7,
+    "average_speed": 9.73,
+    "distance": 13700.5,
+    "moving_time": 1408,
+    "total_elevation_gain": 100.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-23T17:06:02Z",
+    "average_watts": 177.5,
+    "average_speed": 9.079,
+    "distance": 24758.1,
+    "moving_time": 2727,
+    "total_elevation_gain": 360.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-25T14:04:51Z",
+    "average_watts": 141.6,
+    "average_speed": 6.977,
+    "distance": 67728.8,
+    "moving_time": 9707,
+    "total_elevation_gain": 522.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-04-27T06:24:46Z",
+    "average_watts": 145.0,
+    "average_speed": 5.604,
+    "distance": 3783.0,
+    "moving_time": 675,
+    "total_elevation_gain": 47.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-03T14:51:06Z",
+    "average_watts": 158.6,
+    "average_speed": 4.101,
+    "distance": 5389.1,
+    "moving_time": 1314,
+    "total_elevation_gain": 73.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-05T15:44:13Z",
+    "average_watts": 160.0,
+    "average_speed": 5.168,
+    "distance": 88548.1,
+    "moving_time": 17133,
+    "total_elevation_gain": 843.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-07T12:27:36Z",
+    "average_watts": 142.9,
+    "average_speed": 5.104,
+    "distance": 68757.2,
+    "moving_time": 13470,
+    "total_elevation_gain": 729.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-08T13:29:51Z",
+    "average_watts": 145.6,
+    "average_speed": 9.656,
+    "distance": 24930.5,
+    "moving_time": 2582,
+    "total_elevation_gain": 127.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-10T19:32:34Z",
+    "average_watts": 149.2,
+    "average_speed": 5.447,
+    "distance": 57272.2,
+    "moving_time": 10515,
+    "total_elevation_gain": 774.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-11T17:09:22Z",
+    "average_watts": 162.3,
+    "average_speed": 7.961,
+    "distance": 26995.7,
+    "moving_time": 3391,
+    "total_elevation_gain": 188.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-13T17:45:49Z",
+    "average_watts": 162.4,
+    "average_speed": 6.93,
+    "distance": 82611.2,
+    "moving_time": 11921,
+    "total_elevation_gain": 1185.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-15T15:44:26Z",
+    "average_watts": 149.6,
+    "average_speed": 5.987,
+    "distance": 66972.1,
+    "moving_time": 11186,
+    "total_elevation_gain": 961.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-16T11:49:23Z",
+    "average_watts": 175.6,
+    "average_speed": 6.479,
+    "distance": 63604.4,
+    "moving_time": 9817,
+    "total_elevation_gain": 909.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-19T13:31:07Z",
+    "average_watts": 164.8,
+    "average_speed": 5.138,
+    "distance": 60671.3,
+    "moving_time": 11809,
+    "total_elevation_gain": 520.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-20T13:26:47Z",
+    "average_watts": 142.7,
+    "average_speed": 5.963,
+    "distance": 25636.1,
+    "moving_time": 4299,
+    "total_elevation_gain": 277.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-21T09:25:25Z",
+    "average_watts": 165.7,
+    "average_speed": 6.756,
+    "distance": 23674.7,
+    "moving_time": 3504,
+    "total_elevation_gain": 231.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-22T09:02:55Z",
+    "average_watts": 178.4,
+    "average_speed": 4.265,
+    "distance": 7889.5,
+    "moving_time": 1850,
+    "total_elevation_gain": 87.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-25T11:15:16Z",
+    "average_watts": 170.5,
+    "average_speed": 6.897,
+    "distance": 36824.2,
+    "moving_time": 5339,
+    "total_elevation_gain": 512.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-26T14:29:36Z",
+    "average_watts": 169.7,
+    "average_speed": 9.931,
+    "distance": 13009.8,
+    "moving_time": 1310,
+    "total_elevation_gain": 78.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-29T08:17:56Z",
+    "average_watts": 173.6,
+    "average_speed": 6.273,
+    "distance": 94465.2,
+    "moving_time": 15058,
+    "total_elevation_gain": 899.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-05-30T08:23:52Z",
+    "average_watts": 146.4,
+    "average_speed": 8.201,
+    "distance": 11777.3,
+    "moving_time": 1436,
+    "total_elevation_gain": 81.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-01T16:07:41Z",
+    "average_watts": 151.2,
+    "average_speed": 6.223,
+    "distance": 82384.8,
+    "moving_time": 13239,
+    "total_elevation_gain": 681.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-03T16:40:41Z",
+    "average_watts": 173.8,
+    "average_speed": 9.076,
+    "distance": 11127.6,
+    "moving_time": 1226,
+    "total_elevation_gain": 143.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-08T18:46:02Z",
+    "average_watts": 167.1,
+    "average_speed": 5.654,
+    "distance": 32152.2,
+    "moving_time": 5687,
+    "total_elevation_gain": 334.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-09T12:18:35Z",
+    "average_watts": 148.1,
+    "average_speed": 8.844,
+    "distance": 16546.9,
+    "moving_time": 1871,
+    "total_elevation_gain": 235.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-10T19:08:00Z",
+    "average_watts": 141.0,
+    "average_speed": 7.157,
+    "distance": 14221.8,
+    "moving_time": 1987,
+    "total_elevation_gain": 195.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-12T15:35:29Z",
+    "average_watts": 172.2,
+    "average_speed": 3.757,
+    "distance": 5128.4,
+    "moving_time": 1365,
+    "total_elevation_gain": 62.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-13T06:44:08Z",
+    "average_watts": 170.4,
+    "average_speed": 5.101,
+    "distance": 74879.0,
+    "moving_time": 14679,
+    "total_elevation_gain": 687.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-16T07:34:38Z",
+    "average_watts": 146.0,
+    "average_speed": 4.74,
+    "distance": 4768.5,
+    "moving_time": 1006,
+    "total_elevation_gain": 62.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-17T15:50:01Z",
+    "average_watts": 144.1,
+    "average_speed": 8.733,
+    "distance": 21945.0,
+    "moving_time": 2513,
+    "total_elevation_gain": 211.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-19T07:14:18Z",
+    "average_watts": 152.8,
+    "average_speed": 9.128,
+    "distance": 16522.5,
+    "moving_time": 1810,
+    "total_elevation_gain": 234.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-21T13:16:44Z",
+    "average_watts": 161.9,
+    "average_speed": 5.795,
+    "distance": 27567.4,
+    "moving_time": 4757,
+    "total_elevation_gain": 205.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-22T19:43:24Z",
+    "average_watts": 144.9,
+    "average_speed": 7.295,
+    "distance": 33952.7,
+    "moving_time": 4654,
+    "total_elevation_gain": 336.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-24T13:57:31Z",
+    "average_watts": 166.7,
+    "average_speed": 7.57,
+    "distance": 34058.4,
+    "moving_time": 4499,
+    "total_elevation_gain": 230.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-28T13:05:01Z",
+    "average_watts": 163.1,
+    "average_speed": 6.384,
+    "distance": 62837.0,
+    "moving_time": 9843,
+    "total_elevation_gain": 525.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-06-29T15:05:02Z",
+    "average_watts": 164.8,
+    "average_speed": 7.218,
+    "distance": 31044.7,
+    "moving_time": 4301,
+    "total_elevation_gain": 349.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-03T14:22:27Z",
+    "average_watts": 152.9,
+    "average_speed": 6.368,
+    "distance": 25133.8,
+    "moving_time": 3947,
+    "total_elevation_gain": 146.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-05T16:58:38Z",
+    "average_watts": 161.4,
+    "average_speed": 4.586,
+    "distance": 4100.1,
+    "moving_time": 894,
+    "total_elevation_gain": 46.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-06T06:19:41Z",
+    "average_watts": 164.5,
+    "average_speed": 9.553,
+    "distance": 22687.6,
+    "moving_time": 2375,
+    "total_elevation_gain": 201.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-10T16:19:11Z",
+    "average_watts": 156.5,
+    "average_speed": 7.213,
+    "distance": 23429.1,
+    "moving_time": 3248,
+    "total_elevation_gain": 346.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-13T13:08:12Z",
+    "average_watts": 172.3,
+    "average_speed": 7.254,
+    "distance": 13043.3,
+    "moving_time": 1798,
+    "total_elevation_gain": 150.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-14T06:35:50Z",
+    "average_watts": 154.5,
+    "average_speed": 5.57,
+    "distance": 99680.7,
+    "moving_time": 17895,
+    "total_elevation_gain": 834.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-16T07:17:43Z",
+    "average_watts": 180.1,
+    "average_speed": 7.293,
+    "distance": 20703.7,
+    "moving_time": 2839,
+    "total_elevation_gain": 279.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-17T07:09:51Z",
+    "average_watts": 149.7,
+    "average_speed": 3.19,
+    "distance": 4641.9,
+    "moving_time": 1455,
+    "total_elevation_gain": 51.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-18T13:05:14Z",
+    "average_watts": 170.0,
+    "average_speed": 5.236,
+    "distance": 51458.8,
+    "moving_time": 9828,
+    "total_elevation_gain": 501.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-20T07:07:48Z",
+    "average_watts": 176.4,
+    "average_speed": 6.249,
+    "distance": 67369.3,
+    "moving_time": 10781,
+    "total_elevation_gain": 562.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-21T15:36:14Z",
+    "average_watts": 178.0,
+    "average_speed": 9.696,
+    "distance": 19352.5,
+    "moving_time": 1996,
+    "total_elevation_gain": 191.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-22T13:44:26Z",
+    "average_watts": 179.2,
+    "average_speed": 5.717,
+    "distance": 5940.0,
+    "moving_time": 1039,
+    "total_elevation_gain": 70.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-23T08:20:35Z",
+    "average_watts": 163.9,
+    "average_speed": 6.818,
+    "distance": 26264.0,
+    "moving_time": 3852,
+    "total_elevation_gain": 309.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-24T17:56:30Z",
+    "average_watts": 146.1,
+    "average_speed": 6.855,
+    "distance": 53488.8,
+    "moving_time": 7803,
+    "total_elevation_gain": 494.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-28T19:09:57Z",
+    "average_watts": 151.4,
+    "average_speed": 5.809,
+    "distance": 37260.9,
+    "moving_time": 6414,
+    "total_elevation_gain": 369.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-29T13:49:52Z",
+    "average_watts": 181.2,
+    "average_speed": 6.117,
+    "distance": 70317.5,
+    "moving_time": 11496,
+    "total_elevation_gain": 780.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-30T15:07:53Z",
+    "average_watts": 141.8,
+    "average_speed": 5.914,
+    "distance": 64195.0,
+    "moving_time": 10855,
+    "total_elevation_gain": 786.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-07-31T19:15:45Z",
+    "average_watts": 156.9,
+    "average_speed": 6.76,
+    "distance": 94039.8,
+    "moving_time": 13912,
+    "total_elevation_gain": 734.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-01T11:00:20Z",
+    "average_watts": 145.4,
+    "average_speed": 6.049,
+    "distance": 98143.0,
+    "moving_time": 16225,
+    "total_elevation_gain": 828.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-02T19:06:25Z",
+    "average_watts": 179.5,
+    "average_speed": 6.787,
+    "distance": 75945.8,
+    "moving_time": 11190,
+    "total_elevation_gain": 556.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-03T14:21:32Z",
+    "average_watts": 170.8,
+    "average_speed": 7.492,
+    "distance": 22992.4,
+    "moving_time": 3069,
+    "total_elevation_gain": 271.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-04T19:24:59Z",
+    "average_watts": 168.4,
+    "average_speed": 7.18,
+    "distance": 39516.9,
+    "moving_time": 5504,
+    "total_elevation_gain": 380.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-05T08:37:03Z",
+    "average_watts": 142.0,
+    "average_speed": 8.517,
+    "distance": 24486.3,
+    "moving_time": 2875,
+    "total_elevation_gain": 232.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-06T06:35:38Z",
+    "average_watts": 162.3,
+    "average_speed": 9.527,
+    "distance": 17690.8,
+    "moving_time": 1857,
+    "total_elevation_gain": 203.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-07T09:19:06Z",
+    "average_watts": 165.4,
+    "average_speed": 4.699,
+    "distance": 7785.8,
+    "moving_time": 1657,
+    "total_elevation_gain": 60.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-10T07:14:30Z",
+    "average_watts": 147.8,
+    "average_speed": 6.729,
+    "distance": 66981.2,
+    "moving_time": 9954,
+    "total_elevation_gain": 822.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-11T19:00:06Z",
+    "average_watts": 163.6,
+    "average_speed": 7.285,
+    "distance": 29284.7,
+    "moving_time": 4020,
+    "total_elevation_gain": 239.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-14T15:15:06Z",
+    "average_watts": 173.1,
+    "average_speed": 6.066,
+    "distance": 27436.2,
+    "moving_time": 4523,
+    "total_elevation_gain": 212.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-16T18:01:38Z",
+    "average_watts": 164.7,
+    "average_speed": 7.729,
+    "distance": 24137.6,
+    "moving_time": 3123,
+    "total_elevation_gain": 150.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-23T16:19:16Z",
+    "average_watts": 156.3,
+    "average_speed": 8.75,
+    "distance": 17027.9,
+    "moving_time": 1946,
+    "total_elevation_gain": 151.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-24T10:39:09Z",
+    "average_watts": 169.7,
+    "average_speed": 4.451,
+    "distance": 7494.8,
+    "moving_time": 1684,
+    "total_elevation_gain": 45.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-25T19:45:04Z",
+    "average_watts": 175.4,
+    "average_speed": 5.154,
+    "distance": 29999.0,
+    "moving_time": 5820,
+    "total_elevation_gain": 405.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-30T09:52:12Z",
+    "average_watts": 174.2,
+    "average_speed": 5.691,
+    "distance": 32663.4,
+    "moving_time": 5739,
+    "total_elevation_gain": 404.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-08-31T18:17:07Z",
+    "average_watts": 142.5,
+    "average_speed": 6.092,
+    "distance": 69094.8,
+    "moving_time": 11341,
+    "total_elevation_gain": 484.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-02T06:12:52Z",
+    "average_watts": 174.5,
+    "average_speed": 5.533,
+    "distance": 80793.9,
+    "moving_time": 14602,
+    "total_elevation_gain": 505.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-04T11:21:12Z",
+    "average_watts": 174.9,
+    "average_speed": 7.897,
+    "distance": 36927.8,
+    "moving_time": 4676,
+    "total_elevation_gain": 400.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-07T09:49:30Z",
+    "average_watts": 171.6,
+    "average_speed": 5.664,
+    "distance": 21382.2,
+    "moving_time": 3775,
+    "total_elevation_gain": 133.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-08T17:50:02Z",
+    "average_watts": 157.2,
+    "average_speed": 5.183,
+    "distance": 77780.1,
+    "moving_time": 15006,
+    "total_elevation_gain": 1041.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-11T10:15:24Z",
+    "average_watts": 181.2,
+    "average_speed": 6.997,
+    "distance": 66740.8,
+    "moving_time": 9539,
+    "total_elevation_gain": 888.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-12T15:26:03Z",
+    "average_watts": 178.5,
+    "average_speed": 6.763,
+    "distance": 86472.4,
+    "moving_time": 12787,
+    "total_elevation_gain": 600.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-15T08:13:25Z",
+    "average_watts": 164.5,
+    "average_speed": 7.876,
+    "distance": 14837.5,
+    "moving_time": 1884,
+    "total_elevation_gain": 92.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-16T10:42:06Z",
+    "average_watts": 153.3,
+    "average_speed": 6.924,
+    "distance": 92616.4,
+    "moving_time": 13377,
+    "total_elevation_gain": 1284.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-20T13:08:09Z",
+    "average_watts": 166.7,
+    "average_speed": 7.3,
+    "distance": 21716.1,
+    "moving_time": 2975,
+    "total_elevation_gain": 155.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-22T18:22:01Z",
+    "average_watts": 177.3,
+    "average_speed": 3.578,
+    "distance": 3774.6,
+    "moving_time": 1055,
+    "total_elevation_gain": 45.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-24T14:42:36Z",
+    "average_watts": 176.6,
+    "average_speed": 9.924,
+    "distance": 24848.6,
+    "moving_time": 2504,
+    "total_elevation_gain": 314.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-26T12:26:35Z",
+    "average_watts": 153.2,
+    "average_speed": 5.56,
+    "distance": 69576.9,
+    "moving_time": 12513,
+    "total_elevation_gain": 994.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-09-29T09:03:07Z",
+    "average_watts": 153.7,
+    "average_speed": 5.696,
+    "distance": 82659.4,
+    "moving_time": 14513,
+    "total_elevation_gain": 1213.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-05T07:37:23Z",
+    "average_watts": 174.1,
+    "average_speed": 6.982,
+    "distance": 71356.0,
+    "moving_time": 10220,
+    "total_elevation_gain": 953.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-06T07:17:47Z",
+    "average_watts": 181.8,
+    "average_speed": 5.336,
+    "distance": 6120.1,
+    "moving_time": 1147,
+    "total_elevation_gain": 56.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-07T19:18:25Z",
+    "average_watts": 179.8,
+    "average_speed": 6.855,
+    "distance": 78844.8,
+    "moving_time": 11502,
+    "total_elevation_gain": 978.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-10T11:37:12Z",
+    "average_watts": 177.8,
+    "average_speed": 5.362,
+    "distance": 5158.6,
+    "moving_time": 962,
+    "total_elevation_gain": 26.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-11T08:25:51Z",
+    "average_watts": 156.8,
+    "average_speed": 6.037,
+    "distance": 27456.7,
+    "moving_time": 4548,
+    "total_elevation_gain": 349.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-12T07:59:20Z",
+    "average_watts": 180.4,
+    "average_speed": 5.251,
+    "distance": 3255.4,
+    "moving_time": 620,
+    "total_elevation_gain": 21.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-13T07:51:18Z",
+    "average_watts": 161.7,
+    "average_speed": 6.361,
+    "distance": 51626.7,
+    "moving_time": 8116,
+    "total_elevation_gain": 736.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-15T15:55:52Z",
+    "average_watts": 148.1,
+    "average_speed": 7.68,
+    "distance": 24722.8,
+    "moving_time": 3219,
+    "total_elevation_gain": 257.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-16T16:08:12Z",
+    "average_watts": 174.5,
+    "average_speed": 5.382,
+    "distance": 7421.3,
+    "moving_time": 1379,
+    "total_elevation_gain": 85.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-17T18:26:43Z",
+    "average_watts": 169.0,
+    "average_speed": 7.039,
+    "distance": 37737.2,
+    "moving_time": 5361,
+    "total_elevation_gain": 235.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-22T17:43:11Z",
+    "average_watts": 171.9,
+    "average_speed": 8.705,
+    "distance": 14320.1,
+    "moving_time": 1645,
+    "total_elevation_gain": 137.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-24T15:48:57Z",
+    "average_watts": 150.1,
+    "average_speed": 9.593,
+    "distance": 24643.3,
+    "moving_time": 2569,
+    "total_elevation_gain": 251.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-25T14:26:06Z",
+    "average_watts": 164.4,
+    "average_speed": 6.106,
+    "distance": 60637.4,
+    "moving_time": 9931,
+    "total_elevation_gain": 846.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-26T09:07:20Z",
+    "average_watts": 166.7,
+    "average_speed": 9.633,
+    "distance": 11800.5,
+    "moving_time": 1225,
+    "total_elevation_gain": 72.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-10-29T12:43:19Z",
+    "average_watts": 163.5,
+    "average_speed": 5.769,
+    "distance": 6253.5,
+    "moving_time": 1084,
+    "total_elevation_gain": 74.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-01T17:15:20Z",
+    "average_watts": 156.2,
+    "average_speed": 5.979,
+    "distance": 88607.8,
+    "moving_time": 14820,
+    "total_elevation_gain": 1270.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-03T07:12:05Z",
+    "average_watts": 144.2,
+    "average_speed": 6.91,
+    "distance": 80267.7,
+    "moving_time": 11616,
+    "total_elevation_gain": 1154.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-04T14:20:23Z",
+    "average_watts": 161.3,
+    "average_speed": 6.656,
+    "distance": 84066.0,
+    "moving_time": 12630,
+    "total_elevation_gain": 536.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-07T19:21:03Z",
+    "average_watts": 161.7,
+    "average_speed": 7.92,
+    "distance": 39590.4,
+    "moving_time": 4999,
+    "total_elevation_gain": 345.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-14T18:54:46Z",
+    "average_watts": 168.8,
+    "average_speed": 5.611,
+    "distance": 53678.6,
+    "moving_time": 9567,
+    "total_elevation_gain": 402.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-19T17:42:55Z",
+    "average_watts": 161.7,
+    "average_speed": 5.106,
+    "distance": 24743.7,
+    "moving_time": 4846,
+    "total_elevation_gain": 327.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-21T10:21:57Z",
+    "average_watts": 157.2,
+    "average_speed": 7.516,
+    "distance": 12536.2,
+    "moving_time": 1668,
+    "total_elevation_gain": 148.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-22T10:03:18Z",
+    "average_watts": 168.9,
+    "average_speed": 7.979,
+    "distance": 12495.3,
+    "moving_time": 1566,
+    "total_elevation_gain": 128.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-11-30T14:10:56Z",
+    "average_watts": 161.4,
+    "average_speed": 7.63,
+    "distance": 29595.5,
+    "moving_time": 3879,
+    "total_elevation_gain": 310.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-02T09:39:17Z",
+    "average_watts": 163.5,
+    "average_speed": 7.344,
+    "distance": 28481.0,
+    "moving_time": 3878,
+    "total_elevation_gain": 395.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-04T16:42:21Z",
+    "average_watts": 182.8,
+    "average_speed": 8.341,
+    "distance": 21487.6,
+    "moving_time": 2576,
+    "total_elevation_gain": 310.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-07T08:15:23Z",
+    "average_watts": 159.6,
+    "average_speed": 6.008,
+    "distance": 39086.6,
+    "moving_time": 6506,
+    "total_elevation_gain": 200.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-08T13:18:45Z",
+    "average_watts": 170.5,
+    "average_speed": 5.704,
+    "distance": 24716.4,
+    "moving_time": 4333,
+    "total_elevation_gain": 364.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-12T18:33:05Z",
+    "average_watts": 156.2,
+    "average_speed": 8.482,
+    "distance": 21925.9,
+    "moving_time": 2585,
+    "total_elevation_gain": 296.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-15T19:41:32Z",
+    "average_watts": 159.8,
+    "average_speed": 7.601,
+    "distance": 14632.6,
+    "moving_time": 1925,
+    "total_elevation_gain": 187.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-16T19:01:55Z",
+    "average_watts": 179.9,
+    "average_speed": 5.046,
+    "distance": 3693.5,
+    "moving_time": 732,
+    "total_elevation_gain": 49.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-18T09:44:16Z",
+    "average_watts": 174.3,
+    "average_speed": 9.425,
+    "distance": 13543.3,
+    "moving_time": 1437,
+    "total_elevation_gain": 168.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-22T13:23:15Z",
+    "average_watts": 176.3,
+    "average_speed": 4.694,
+    "distance": 5994.2,
+    "moving_time": 1277,
+    "total_elevation_gain": 34.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-24T14:42:26Z",
+    "average_watts": 157.4,
+    "average_speed": 3.475,
+    "distance": 3040.6,
+    "moving_time": 875,
+    "total_elevation_gain": 27.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-26T07:25:13Z",
+    "average_watts": 153.4,
+    "average_speed": 7.671,
+    "distance": 32771.1,
+    "moving_time": 4272,
+    "total_elevation_gain": 445.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2022-12-28T06:35:05Z",
+    "average_watts": 149.2,
+    "average_speed": 7.701,
+    "distance": 21795.1,
+    "moving_time": 2830,
+    "total_elevation_gain": 177.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-03T07:59:33Z",
+    "average_watts": 172.1,
+    "average_speed": 5.914,
+    "distance": 27984.3,
+    "moving_time": 4732,
+    "total_elevation_gain": 182.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-09T14:09:45Z",
+    "average_watts": 164.1,
+    "average_speed": 9.595,
+    "distance": 10228.4,
+    "moving_time": 1066,
+    "total_elevation_gain": 81.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-10T14:55:37Z",
+    "average_watts": 165.7,
+    "average_speed": 6.298,
+    "distance": 78901.6,
+    "moving_time": 12528,
+    "total_elevation_gain": 828.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-12T16:23:48Z",
+    "average_watts": 158.4,
+    "average_speed": 5.426,
+    "distance": 3749.5,
+    "moving_time": 691,
+    "total_elevation_gain": 50.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-15T08:07:47Z",
+    "average_watts": 145.4,
+    "average_speed": 7.682,
+    "distance": 10961.9,
+    "moving_time": 1427,
+    "total_elevation_gain": 111.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-16T19:53:05Z",
+    "average_watts": 156.6,
+    "average_speed": 3.065,
+    "distance": 7920.8,
+    "moving_time": 2584,
+    "total_elevation_gain": 76.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-18T10:12:48Z",
+    "average_watts": 158.9,
+    "average_speed": 6.481,
+    "distance": 66180.7,
+    "moving_time": 10211,
+    "total_elevation_gain": 868.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-22T06:35:32Z",
+    "average_watts": 149.1,
+    "average_speed": 5.118,
+    "distance": 25291.6,
+    "moving_time": 4942,
+    "total_elevation_gain": 338.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-24T19:49:31Z",
+    "average_watts": 165.8,
+    "average_speed": 9.128,
+    "distance": 18711.9,
+    "moving_time": 2050,
+    "total_elevation_gain": 166.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-26T17:47:01Z",
+    "average_watts": 166.8,
+    "average_speed": 5.497,
+    "distance": 5441.9,
+    "moving_time": 990,
+    "total_elevation_gain": 36.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-27T07:12:10Z",
+    "average_watts": 168.7,
+    "average_speed": 9.378,
+    "distance": 15820.9,
+    "moving_time": 1687,
+    "total_elevation_gain": 109.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-28T17:50:15Z",
+    "average_watts": 180.0,
+    "average_speed": 8.929,
+    "distance": 10867.2,
+    "moving_time": 1217,
+    "total_elevation_gain": 127.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-29T18:57:33Z",
+    "average_watts": 156.4,
+    "average_speed": 6.211,
+    "distance": 30245.5,
+    "moving_time": 4870,
+    "total_elevation_gain": 341.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-01-31T17:24:10Z",
+    "average_watts": 159.6,
+    "average_speed": 8.414,
+    "distance": 24443.0,
+    "moving_time": 2905,
+    "total_elevation_gain": 178.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-01T06:15:02Z",
+    "average_watts": 151.0,
+    "average_speed": 5.058,
+    "distance": 4410.7,
+    "moving_time": 872,
+    "total_elevation_gain": 32.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-03T07:17:52Z",
+    "average_watts": 168.7,
+    "average_speed": 8.033,
+    "distance": 12114.1,
+    "moving_time": 1508,
+    "total_elevation_gain": 99.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-06T16:10:48Z",
+    "average_watts": 162.0,
+    "average_speed": 6.553,
+    "distance": 38327.2,
+    "moving_time": 5849,
+    "total_elevation_gain": 301.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-08T18:32:47Z",
+    "average_watts": 146.2,
+    "average_speed": 3.292,
+    "distance": 4859.0,
+    "moving_time": 1476,
+    "total_elevation_gain": 28.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-10T17:42:20Z",
+    "average_watts": 153.8,
+    "average_speed": 6.384,
+    "distance": 78839.3,
+    "moving_time": 12349,
+    "total_elevation_gain": 402.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-11T10:51:47Z",
+    "average_watts": 147.4,
+    "average_speed": 9.842,
+    "distance": 18798.1,
+    "moving_time": 1910,
+    "total_elevation_gain": 239.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-14T14:00:49Z",
+    "average_watts": 156.8,
+    "average_speed": 5.159,
+    "distance": 58797.6,
+    "moving_time": 11398,
+    "total_elevation_gain": 561.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-16T16:39:38Z",
+    "average_watts": 155.6,
+    "average_speed": 5.928,
+    "distance": 65944.3,
+    "moving_time": 11125,
+    "total_elevation_gain": 673.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-17T13:13:00Z",
+    "average_watts": 175.5,
+    "average_speed": 4.121,
+    "distance": 3375.3,
+    "moving_time": 819,
+    "total_elevation_gain": 18.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-21T14:39:38Z",
+    "average_watts": 167.1,
+    "average_speed": 6.498,
+    "distance": 80781.7,
+    "moving_time": 12431,
+    "total_elevation_gain": 911.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-22T08:01:13Z",
+    "average_watts": 153.9,
+    "average_speed": 3.779,
+    "distance": 7613.9,
+    "moving_time": 2015,
+    "total_elevation_gain": 101.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-25T17:39:10Z",
+    "average_watts": 150.6,
+    "average_speed": 7.574,
+    "distance": 18541.5,
+    "moving_time": 2448,
+    "total_elevation_gain": 274.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-26T11:49:54Z",
+    "average_watts": 158.9,
+    "average_speed": 6.356,
+    "distance": 37264.3,
+    "moving_time": 5863,
+    "total_elevation_gain": 385.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-02-28T06:48:45Z",
+    "average_watts": 144.5,
+    "average_speed": 6.585,
+    "distance": 59146.5,
+    "moving_time": 8982,
+    "total_elevation_gain": 750.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-01T09:59:02Z",
+    "average_watts": 170.1,
+    "average_speed": 6.251,
+    "distance": 83586.1,
+    "moving_time": 13371,
+    "total_elevation_gain": 917.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-06T15:57:13Z",
+    "average_watts": 181.2,
+    "average_speed": 7.788,
+    "distance": 23333.6,
+    "moving_time": 2996,
+    "total_elevation_gain": 294.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-07T13:17:00Z",
+    "average_watts": 144.9,
+    "average_speed": 6.396,
+    "distance": 55494.8,
+    "moving_time": 8677,
+    "total_elevation_gain": 432.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-10T14:18:59Z",
+    "average_watts": 173.0,
+    "average_speed": 5.143,
+    "distance": 64422.6,
+    "moving_time": 12526,
+    "total_elevation_gain": 689.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-12T11:32:44Z",
+    "average_watts": 167.1,
+    "average_speed": 4.312,
+    "distance": 6683.8,
+    "moving_time": 1550,
+    "total_elevation_gain": 65.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-13T11:04:58Z",
+    "average_watts": 161.6,
+    "average_speed": 3.196,
+    "distance": 6254.0,
+    "moving_time": 1957,
+    "total_elevation_gain": 45.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-14T13:18:39Z",
+    "average_watts": 155.5,
+    "average_speed": 9.154,
+    "distance": 14581.9,
+    "moving_time": 1593,
+    "total_elevation_gain": 103.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-15T08:24:28Z",
+    "average_watts": 170.1,
+    "average_speed": 7.614,
+    "distance": 22546.3,
+    "moving_time": 2961,
+    "total_elevation_gain": 136.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-16T08:46:17Z",
+    "average_watts": 172.7,
+    "average_speed": 6.583,
+    "distance": 64509.1,
+    "moving_time": 9800,
+    "total_elevation_gain": 531.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-17T13:13:58Z",
+    "average_watts": 183.5,
+    "average_speed": 9.018,
+    "distance": 15321.9,
+    "moving_time": 1699,
+    "total_elevation_gain": 154.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-18T11:59:31Z",
+    "average_watts": 173.2,
+    "average_speed": 7.202,
+    "distance": 24559.6,
+    "moving_time": 3410,
+    "total_elevation_gain": 157.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-21T12:47:44Z",
+    "average_watts": 168.7,
+    "average_speed": 5.623,
+    "distance": 78057.7,
+    "moving_time": 13882,
+    "total_elevation_gain": 869.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-24T06:41:39Z",
+    "average_watts": 163.1,
+    "average_speed": 5.194,
+    "distance": 34761.7,
+    "moving_time": 6693,
+    "total_elevation_gain": 220.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-25T07:44:29Z",
+    "average_watts": 149.2,
+    "average_speed": 8.697,
+    "distance": 23770.2,
+    "moving_time": 2733,
+    "total_elevation_gain": 267.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-26T09:53:14Z",
+    "average_watts": 165.7,
+    "average_speed": 6.546,
+    "distance": 59027.6,
+    "moving_time": 9017,
+    "total_elevation_gain": 618.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-27T14:29:40Z",
+    "average_watts": 164.9,
+    "average_speed": 5.387,
+    "distance": 51506.9,
+    "moving_time": 9562,
+    "total_elevation_gain": 593.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-03-31T14:03:05Z",
+    "average_watts": 152.8,
+    "average_speed": 8.917,
+    "distance": 13044.8,
+    "moving_time": 1463,
+    "total_elevation_gain": 152.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-01T12:12:15Z",
+    "average_watts": 180.7,
+    "average_speed": 5.036,
+    "distance": 24597.5,
+    "moving_time": 4884,
+    "total_elevation_gain": 216.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-02T13:29:49Z",
+    "average_watts": 162.4,
+    "average_speed": 5.124,
+    "distance": 36950.4,
+    "moving_time": 7211,
+    "total_elevation_gain": 475.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-05T12:09:04Z",
+    "average_watts": 154.8,
+    "average_speed": 9.304,
+    "distance": 21036.1,
+    "moving_time": 2261,
+    "total_elevation_gain": 216.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-07T10:27:47Z",
+    "average_watts": 180.7,
+    "average_speed": 9.101,
+    "distance": 19968.6,
+    "moving_time": 2194,
+    "total_elevation_gain": 176.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-08T10:41:52Z",
+    "average_watts": 164.7,
+    "average_speed": 7.623,
+    "distance": 14331.5,
+    "moving_time": 1880,
+    "total_elevation_gain": 119.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-11T19:35:22Z",
+    "average_watts": 172.9,
+    "average_speed": 6.907,
+    "distance": 88901.9,
+    "moving_time": 12872,
+    "total_elevation_gain": 855.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-12T11:36:34Z",
+    "average_watts": 170.2,
+    "average_speed": 7.082,
+    "distance": 12562.9,
+    "moving_time": 1774,
+    "total_elevation_gain": 86.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-16T13:41:00Z",
+    "average_watts": 182.8,
+    "average_speed": 8.355,
+    "distance": 10159.7,
+    "moving_time": 1216,
+    "total_elevation_gain": 82.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-18T18:28:34Z",
+    "average_watts": 158.8,
+    "average_speed": 3.012,
+    "distance": 3065.9,
+    "moving_time": 1018,
+    "total_elevation_gain": 35.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-19T10:50:36Z",
+    "average_watts": 183.1,
+    "average_speed": 5.334,
+    "distance": 5622.3,
+    "moving_time": 1054,
+    "total_elevation_gain": 51.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-20T19:35:12Z",
+    "average_watts": 169.0,
+    "average_speed": 8.064,
+    "distance": 17088.6,
+    "moving_time": 2119,
+    "total_elevation_gain": 110.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-21T19:07:17Z",
+    "average_watts": 153.7,
+    "average_speed": 5.139,
+    "distance": 4810.0,
+    "moving_time": 936,
+    "total_elevation_gain": 63.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-22T15:01:11Z",
+    "average_watts": 180.1,
+    "average_speed": 8.123,
+    "distance": 24150.9,
+    "moving_time": 2973,
+    "total_elevation_gain": 224.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-25T11:00:16Z",
+    "average_watts": 158.3,
+    "average_speed": 5.961,
+    "distance": 7666.4,
+    "moving_time": 1286,
+    "total_elevation_gain": 69.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-27T18:52:46Z",
+    "average_watts": 145.2,
+    "average_speed": 8.417,
+    "distance": 11194.4,
+    "moving_time": 1330,
+    "total_elevation_gain": 148.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-28T18:31:04Z",
+    "average_watts": 164.1,
+    "average_speed": 9.21,
+    "distance": 24203.2,
+    "moving_time": 2628,
+    "total_elevation_gain": 291.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-04-30T15:29:38Z",
+    "average_watts": 154.8,
+    "average_speed": 5.415,
+    "distance": 6979.4,
+    "moving_time": 1289,
+    "total_elevation_gain": 52.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-01T06:17:47Z",
+    "average_watts": 180.9,
+    "average_speed": 3.709,
+    "distance": 6390.8,
+    "moving_time": 1723,
+    "total_elevation_gain": 39.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-03T11:08:10Z",
+    "average_watts": 183.5,
+    "average_speed": 4.783,
+    "distance": 7399.4,
+    "moving_time": 1547,
+    "total_elevation_gain": 72.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-05T18:01:49Z",
+    "average_watts": 183.4,
+    "average_speed": 4.121,
+    "distance": 6746.6,
+    "moving_time": 1637,
+    "total_elevation_gain": 56.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-06T14:43:22Z",
+    "average_watts": 170.9,
+    "average_speed": 9.754,
+    "distance": 21596.3,
+    "moving_time": 2214,
+    "total_elevation_gain": 195.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-08T15:03:26Z",
+    "average_watts": 158.9,
+    "average_speed": 5.532,
+    "distance": 6494.6,
+    "moving_time": 1174,
+    "total_elevation_gain": 45.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-09T15:11:32Z",
+    "average_watts": 172.3,
+    "average_speed": 8.722,
+    "distance": 19204.9,
+    "moving_time": 2202,
+    "total_elevation_gain": 127.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-13T18:17:33Z",
+    "average_watts": 157.5,
+    "average_speed": 4.227,
+    "distance": 4400.8,
+    "moving_time": 1041,
+    "total_elevation_gain": 31.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-14T18:08:47Z",
+    "average_watts": 171.1,
+    "average_speed": 7.016,
+    "distance": 37196.2,
+    "moving_time": 5302,
+    "total_elevation_gain": 540.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-16T14:49:26Z",
+    "average_watts": 155.7,
+    "average_speed": 9.425,
+    "distance": 19830.4,
+    "moving_time": 2104,
+    "total_elevation_gain": 270.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-17T12:32:32Z",
+    "average_watts": 170.2,
+    "average_speed": 5.083,
+    "distance": 52805.9,
+    "moving_time": 10388,
+    "total_elevation_gain": 721.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-21T15:16:17Z",
+    "average_watts": 172.7,
+    "average_speed": 6.626,
+    "distance": 28897.3,
+    "moving_time": 4361,
+    "total_elevation_gain": 416.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-24T09:52:32Z",
+    "average_watts": 173.3,
+    "average_speed": 3.422,
+    "distance": 3463.3,
+    "moving_time": 1012,
+    "total_elevation_gain": 21.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-25T16:18:54Z",
+    "average_watts": 157.3,
+    "average_speed": 9.047,
+    "distance": 15389.1,
+    "moving_time": 1701,
+    "total_elevation_gain": 221.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-28T07:00:42Z",
     "average_watts": 180.3,
+    "average_speed": 9.778,
+    "distance": 19146.2,
+    "moving_time": 1958,
+    "total_elevation_gain": 127.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-29T19:24:56Z",
+    "average_watts": 178.8,
+    "average_speed": 3.273,
+    "distance": 4722.9,
+    "moving_time": 1443,
+    "total_elevation_gain": 47.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-05-30T18:11:29Z",
+    "average_watts": 146.1,
+    "average_speed": 5.306,
+    "distance": 5104.4,
+    "moving_time": 962,
+    "total_elevation_gain": 41.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-02T08:18:10Z",
+    "average_watts": 148.9,
+    "average_speed": 4.685,
+    "distance": 4258.3,
+    "moving_time": 909,
+    "total_elevation_gain": 53.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-05T19:53:17Z",
+    "average_watts": 171.7,
+    "average_speed": 7.339,
+    "distance": 28658.9,
+    "moving_time": 3905,
+    "total_elevation_gain": 309.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-06T08:08:45Z",
+    "average_watts": 160.2,
+    "average_speed": 7.892,
+    "distance": 14442.6,
+    "moving_time": 1830,
+    "total_elevation_gain": 143.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-09T19:41:23Z",
+    "average_watts": 154.5,
+    "average_speed": 6.525,
+    "distance": 74224.6,
+    "moving_time": 11376,
+    "total_elevation_gain": 596.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-12T08:20:08Z",
+    "average_watts": 172.6,
+    "average_speed": 4.396,
+    "distance": 5604.3,
+    "moving_time": 1275,
+    "total_elevation_gain": 54.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-14T12:01:01Z",
+    "average_watts": 152.8,
+    "average_speed": 5.301,
+    "distance": 38812.1,
+    "moving_time": 7322,
+    "total_elevation_gain": 376.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-15T19:10:05Z",
+    "average_watts": 151.2,
+    "average_speed": 7.091,
+    "distance": 38168.5,
+    "moving_time": 5383,
+    "total_elevation_gain": 196.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-17T10:46:25Z",
+    "average_watts": 182.2,
+    "average_speed": 8.779,
+    "distance": 19753.8,
+    "moving_time": 2250,
+    "total_elevation_gain": 293.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-19T10:07:05Z",
+    "average_watts": 158.6,
+    "average_speed": 4.822,
+    "distance": 7411.9,
+    "moving_time": 1537,
+    "total_elevation_gain": 52.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-22T16:26:39Z",
+    "average_watts": 183.4,
+    "average_speed": 3.61,
+    "distance": 4491.0,
+    "moving_time": 1244,
+    "total_elevation_gain": 61.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-23T08:16:47Z",
+    "average_watts": 156.2,
+    "average_speed": 6.477,
+    "distance": 92087.8,
+    "moving_time": 14217,
+    "total_elevation_gain": 697.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-06-26T16:17:18Z",
+    "average_watts": 170.2,
+    "average_speed": 5.042,
+    "distance": 87562.5,
+    "moving_time": 17368,
+    "total_elevation_gain": 1231.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-03T15:00:30Z",
+    "average_watts": 172.1,
+    "average_speed": 9.257,
+    "distance": 19134.9,
+    "moving_time": 2067,
+    "total_elevation_gain": 138.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-06T12:20:22Z",
+    "average_watts": 158.3,
+    "average_speed": 5.37,
+    "distance": 30805.2,
+    "moving_time": 5736,
+    "total_elevation_gain": 390.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-09T09:07:03Z",
+    "average_watts": 160.9,
+    "average_speed": 6.977,
+    "distance": 97624.7,
+    "moving_time": 13992,
+    "total_elevation_gain": 1143.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-10T09:22:04Z",
+    "average_watts": 174.5,
+    "average_speed": 9.329,
+    "distance": 11493.3,
+    "moving_time": 1232,
+    "total_elevation_gain": 77.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-12T19:53:05Z",
+    "average_watts": 170.1,
+    "average_speed": 6.145,
+    "distance": 78050.7,
+    "moving_time": 12702,
+    "total_elevation_gain": 881.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-15T09:02:15Z",
+    "average_watts": 166.9,
+    "average_speed": 5.587,
+    "distance": 29342.6,
+    "moving_time": 5252,
+    "total_elevation_gain": 153.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-22T18:25:28Z",
+    "average_watts": 178.9,
+    "average_speed": 5.54,
+    "distance": 5800.5,
+    "moving_time": 1047,
+    "total_elevation_gain": 51.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-25T19:39:12Z",
+    "average_watts": 151.5,
+    "average_speed": 6.49,
+    "distance": 34453.1,
+    "moving_time": 5309,
+    "total_elevation_gain": 395.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-27T12:32:39Z",
+    "average_watts": 153.3,
+    "average_speed": 8.641,
+    "distance": 12218.9,
+    "moving_time": 1414,
+    "total_elevation_gain": 109.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-29T16:03:45Z",
+    "average_watts": 179.3,
+    "average_speed": 4.514,
+    "distance": 6477.2,
+    "moving_time": 1435,
+    "total_elevation_gain": 81.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-07-30T18:36:03Z",
+    "average_watts": 151.6,
+    "average_speed": 5.635,
+    "distance": 55361.8,
+    "moving_time": 9825,
+    "total_elevation_gain": 503.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-04T06:43:04Z",
+    "average_watts": 171.4,
+    "average_speed": 7.941,
+    "distance": 21464.0,
+    "moving_time": 2703,
+    "total_elevation_gain": 198.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-05T12:00:21Z",
+    "average_watts": 185.5,
     "average_speed": 8.611,
-    "distance": 11659.2,
-    "moving_time": 1354,
-    "total_elevation_gain": 95.6
+    "distance": 14337.9,
+    "moving_time": 1665,
+    "total_elevation_gain": 156.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-07T11:20:51Z",
+    "average_watts": 150.0,
+    "average_speed": 5.545,
+    "distance": 6238.2,
+    "moving_time": 1125,
+    "total_elevation_gain": 87.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-09T11:08:16Z",
+    "average_watts": 183.3,
+    "average_speed": 6.779,
+    "distance": 62370.6,
+    "moving_time": 9201,
+    "total_elevation_gain": 377.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-17T15:29:32Z",
+    "average_watts": 159.9,
+    "average_speed": 5.479,
+    "distance": 4739.1,
+    "moving_time": 865,
+    "total_elevation_gain": 60.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-19T14:51:43Z",
+    "average_watts": 175.5,
+    "average_speed": 6.345,
+    "distance": 21406.4,
+    "moving_time": 3374,
+    "total_elevation_gain": 174.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-20T19:00:13Z",
+    "average_watts": 151.8,
+    "average_speed": 5.245,
+    "distance": 99719.0,
+    "moving_time": 19013,
+    "total_elevation_gain": 1216.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-21T09:11:55Z",
+    "average_watts": 163.6,
+    "average_speed": 8.083,
+    "distance": 10403.3,
+    "moving_time": 1287,
+    "total_elevation_gain": 154.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-22T10:05:10Z",
+    "average_watts": 164.8,
+    "average_speed": 6.194,
+    "distance": 37676.1,
+    "moving_time": 6083,
+    "total_elevation_gain": 401.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-23T14:47:36Z",
+    "average_watts": 185.6,
+    "average_speed": 5.892,
+    "distance": 61609.3,
+    "moving_time": 10457,
+    "total_elevation_gain": 794.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-25T07:54:46Z",
+    "average_watts": 172.4,
+    "average_speed": 5.774,
+    "distance": 25225.2,
+    "moving_time": 4369,
+    "total_elevation_gain": 361.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-26T14:42:19Z",
+    "average_watts": 149.9,
+    "average_speed": 5.778,
+    "distance": 4847.6,
+    "moving_time": 839,
+    "total_elevation_gain": 60.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-30T13:21:23Z",
+    "average_watts": 157.7,
+    "average_speed": 5.753,
+    "distance": 5522.6,
+    "moving_time": 960,
+    "total_elevation_gain": 47.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-08-31T12:52:12Z",
+    "average_watts": 153.0,
+    "average_speed": 3.952,
+    "distance": 7784.5,
+    "moving_time": 1970,
+    "total_elevation_gain": 74.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-05T11:34:39Z",
+    "average_watts": 147.1,
+    "average_speed": 7.982,
+    "distance": 36590.3,
+    "moving_time": 4584,
+    "total_elevation_gain": 401.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-06T12:59:17Z",
+    "average_watts": 147.8,
+    "average_speed": 5.409,
+    "distance": 3921.3,
+    "moving_time": 725,
+    "total_elevation_gain": 33.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-07T11:20:09Z",
+    "average_watts": 166.6,
+    "average_speed": 5.087,
+    "distance": 20814.2,
+    "moving_time": 4092,
+    "total_elevation_gain": 196.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-08T07:06:21Z",
+    "average_watts": 173.4,
+    "average_speed": 7.852,
+    "distance": 13584.5,
+    "moving_time": 1730,
+    "total_elevation_gain": 163.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-09T14:12:50Z",
+    "average_watts": 149.5,
+    "average_speed": 7.62,
+    "distance": 17823.5,
+    "moving_time": 2339,
+    "total_elevation_gain": 100.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-10T19:46:29Z",
+    "average_watts": 156.3,
+    "average_speed": 8.697,
+    "distance": 14645.0,
+    "moving_time": 1684,
+    "total_elevation_gain": 96.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-12T11:27:51Z",
+    "average_watts": 165.0,
+    "average_speed": 9.463,
+    "distance": 17155.8,
+    "moving_time": 1813,
+    "total_elevation_gain": 180.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-15T09:51:51Z",
+    "average_watts": 154.8,
+    "average_speed": 4.352,
+    "distance": 6610.7,
+    "moving_time": 1519,
+    "total_elevation_gain": 48.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-16T18:42:46Z",
+    "average_watts": 161.0,
+    "average_speed": 3.646,
+    "distance": 4211.6,
+    "moving_time": 1155,
+    "total_elevation_gain": 42.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-18T10:25:26Z",
+    "average_watts": 168.0,
+    "average_speed": 5.451,
+    "distance": 60989.7,
+    "moving_time": 11189,
+    "total_elevation_gain": 530.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-22T14:18:24Z",
+    "average_watts": 149.7,
+    "average_speed": 7.061,
+    "distance": 34519.1,
+    "moving_time": 4889,
+    "total_elevation_gain": 351.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-24T08:35:56Z",
+    "average_watts": 147.6,
+    "average_speed": 6.14,
+    "distance": 83901.9,
+    "moving_time": 13665,
+    "total_elevation_gain": 483.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-27T10:04:03Z",
+    "average_watts": 174.8,
+    "average_speed": 8.753,
+    "distance": 17401.9,
+    "moving_time": 1988,
+    "total_elevation_gain": 232.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-29T13:05:41Z",
+    "average_watts": 164.4,
+    "average_speed": 6.922,
+    "distance": 62687.7,
+    "moving_time": 9056,
+    "total_elevation_gain": 869.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-09-30T08:43:31Z",
+    "average_watts": 179.5,
+    "average_speed": 5.251,
+    "distance": 73287.3,
+    "moving_time": 13958,
+    "total_elevation_gain": 1069.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-01T06:21:14Z",
+    "average_watts": 171.5,
+    "average_speed": 7.056,
+    "distance": 20031.0,
+    "moving_time": 2839,
+    "total_elevation_gain": 106.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-03T18:02:49Z",
+    "average_watts": 177.3,
+    "average_speed": 7.596,
+    "distance": 21010.0,
+    "moving_time": 2766,
+    "total_elevation_gain": 259.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-04T18:14:23Z",
+    "average_watts": 187.0,
+    "average_speed": 9.149,
+    "distance": 13668.6,
+    "moving_time": 1494,
+    "total_elevation_gain": 83.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-06T18:18:12Z",
+    "average_watts": 156.1,
+    "average_speed": 5.612,
+    "distance": 37033.4,
+    "moving_time": 6599,
+    "total_elevation_gain": 434.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-09T18:28:37Z",
+    "average_watts": 153.5,
+    "average_speed": 3.057,
+    "distance": 5637.6,
+    "moving_time": 1844,
+    "total_elevation_gain": 68.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-10T17:55:49Z",
+    "average_watts": 170.2,
+    "average_speed": 3.055,
+    "distance": 6251.2,
+    "moving_time": 2046,
+    "total_elevation_gain": 56.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-13T18:28:33Z",
+    "average_watts": 176.4,
+    "average_speed": 5.326,
+    "distance": 50813.9,
+    "moving_time": 9541,
+    "total_elevation_gain": 299.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-14T07:51:08Z",
+    "average_watts": 161.3,
+    "average_speed": 3.903,
+    "distance": 7906.7,
+    "moving_time": 2026,
+    "total_elevation_gain": 98.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-19T19:41:06Z",
+    "average_watts": 184.1,
+    "average_speed": 5.936,
+    "distance": 7781.9,
+    "moving_time": 1311,
+    "total_elevation_gain": 61.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-20T17:52:16Z",
+    "average_watts": 152.1,
+    "average_speed": 3.747,
+    "distance": 4106.7,
+    "moving_time": 1096,
+    "total_elevation_gain": 37.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-21T06:59:07Z",
+    "average_watts": 181.9,
+    "average_speed": 4.447,
+    "distance": 5941.5,
+    "moving_time": 1336,
+    "total_elevation_gain": 53.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-23T17:32:19Z",
+    "average_watts": 181.8,
+    "average_speed": 4.6,
+    "distance": 6734.7,
+    "moving_time": 1464,
+    "total_elevation_gain": 94.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-24T10:09:41Z",
+    "average_watts": 160.7,
+    "average_speed": 5.382,
+    "distance": 7153.1,
+    "moving_time": 1329,
+    "total_elevation_gain": 60.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-27T18:35:29Z",
+    "average_watts": 173.9,
+    "average_speed": 5.03,
+    "distance": 36386.9,
+    "moving_time": 7234,
+    "total_elevation_gain": 423.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-29T17:52:56Z",
+    "average_watts": 179.3,
+    "average_speed": 8.662,
+    "distance": 12360.6,
+    "moving_time": 1427,
+    "total_elevation_gain": 73.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-30T15:19:16Z",
+    "average_watts": 185.5,
+    "average_speed": 9.331,
+    "distance": 20799.1,
+    "moving_time": 2229,
+    "total_elevation_gain": 310.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-10-31T10:33:47Z",
+    "average_watts": 171.0,
+    "average_speed": 5.598,
+    "distance": 37595.9,
+    "moving_time": 6716,
+    "total_elevation_gain": 258.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-01T10:24:03Z",
+    "average_watts": 155.9,
+    "average_speed": 5.31,
+    "distance": 34049.1,
+    "moving_time": 6412,
+    "total_elevation_gain": 327.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-02T18:13:15Z",
+    "average_watts": 183.5,
+    "average_speed": 6.836,
+    "distance": 31604.9,
+    "moving_time": 4623,
+    "total_elevation_gain": 371.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-05T07:33:05Z",
+    "average_watts": 157.3,
+    "average_speed": 6.735,
+    "distance": 64709.4,
+    "moving_time": 9608,
+    "total_elevation_gain": 595.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-08T11:44:10Z",
+    "average_watts": 167.5,
+    "average_speed": 5.287,
+    "distance": 83525.0,
+    "moving_time": 15798,
+    "total_elevation_gain": 720.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-09T17:54:12Z",
+    "average_watts": 170.7,
+    "average_speed": 6.32,
+    "distance": 80782.7,
+    "moving_time": 12783,
+    "total_elevation_gain": 648.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-10T10:06:37Z",
+    "average_watts": 153.1,
+    "average_speed": 8.737,
+    "distance": 10982.9,
+    "moving_time": 1257,
+    "total_elevation_gain": 55.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-11T12:33:44Z",
+    "average_watts": 185.8,
+    "average_speed": 5.909,
+    "distance": 59316.7,
+    "moving_time": 10039,
+    "total_elevation_gain": 537.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-15T19:29:17Z",
+    "average_watts": 172.6,
+    "average_speed": 9.378,
+    "distance": 11140.5,
+    "moving_time": 1188,
+    "total_elevation_gain": 76.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-18T09:53:40Z",
+    "average_watts": 147.9,
+    "average_speed": 5.43,
+    "distance": 80452.3,
+    "moving_time": 14817,
+    "total_elevation_gain": 442.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-19T07:46:30Z",
+    "average_watts": 171.8,
+    "average_speed": 5.653,
+    "distance": 32326.4,
+    "moving_time": 5718,
+    "total_elevation_gain": 256.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-20T19:38:06Z",
+    "average_watts": 184.2,
+    "average_speed": 6.474,
+    "distance": 35529.2,
+    "moving_time": 5488,
+    "total_elevation_gain": 209.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-22T08:17:33Z",
+    "average_watts": 157.5,
+    "average_speed": 7.245,
+    "distance": 36043.2,
+    "moving_time": 4975,
+    "total_elevation_gain": 536.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-26T07:08:21Z",
+    "average_watts": 164.0,
+    "average_speed": 9.088,
+    "distance": 15158.1,
+    "moving_time": 1668,
+    "total_elevation_gain": 165.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-27T06:12:40Z",
+    "average_watts": 173.5,
+    "average_speed": 7.906,
+    "distance": 18365.1,
+    "moving_time": 2323,
+    "total_elevation_gain": 231.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-28T08:05:14Z",
+    "average_watts": 154.3,
+    "average_speed": 8.897,
+    "distance": 18620.5,
+    "moving_time": 2093,
+    "total_elevation_gain": 125.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-29T09:52:14Z",
+    "average_watts": 165.1,
+    "average_speed": 5.94,
+    "distance": 79975.7,
+    "moving_time": 13464,
+    "total_elevation_gain": 1028.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-11-30T17:19:43Z",
+    "average_watts": 151.5,
+    "average_speed": 5.461,
+    "distance": 29710.2,
+    "moving_time": 5440,
+    "total_elevation_gain": 368.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-01T19:40:08Z",
+    "average_watts": 154.3,
+    "average_speed": 5.85,
+    "distance": 96587.3,
+    "moving_time": 16510,
+    "total_elevation_gain": 949.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-02T19:36:20Z",
+    "average_watts": 157.9,
+    "average_speed": 5.252,
+    "distance": 26371.6,
+    "moving_time": 5021,
+    "total_elevation_gain": 134.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-03T19:23:36Z",
+    "average_watts": 180.1,
+    "average_speed": 5.415,
+    "distance": 59142.4,
+    "moving_time": 10922,
+    "total_elevation_gain": 678.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-04T19:24:36Z",
+    "average_watts": 151.6,
+    "average_speed": 9.719,
+    "distance": 22733.9,
+    "moving_time": 2339,
+    "total_elevation_gain": 162.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-05T16:51:12Z",
+    "average_watts": 169.5,
+    "average_speed": 9.842,
+    "distance": 12588.5,
+    "moving_time": 1279,
+    "total_elevation_gain": 93.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-07T08:31:28Z",
+    "average_watts": 159.1,
+    "average_speed": 3.777,
+    "distance": 3844.8,
+    "moving_time": 1018,
+    "total_elevation_gain": 48.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-08T07:08:05Z",
+    "average_watts": 159.1,
+    "average_speed": 6.354,
+    "distance": 26649.7,
+    "moving_time": 4194,
+    "total_elevation_gain": 312.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-10T06:51:45Z",
+    "average_watts": 178.9,
+    "average_speed": 4.667,
+    "distance": 3122.0,
+    "moving_time": 669,
+    "total_elevation_gain": 43.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-11T07:55:36Z",
+    "average_watts": 184.5,
+    "average_speed": 5.362,
+    "distance": 99029.6,
+    "moving_time": 18468,
+    "total_elevation_gain": 604.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-13T19:23:20Z",
+    "average_watts": 154.4,
+    "average_speed": 4.027,
+    "distance": 7040.0,
+    "moving_time": 1748,
+    "total_elevation_gain": 91.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-17T18:51:39Z",
+    "average_watts": 186.9,
+    "average_speed": 5.985,
+    "distance": 31429.6,
+    "moving_time": 5251,
+    "total_elevation_gain": 220.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-20T19:46:05Z",
+    "average_watts": 159.1,
+    "average_speed": 5.386,
+    "distance": 26619.2,
+    "moving_time": 4942,
+    "total_elevation_gain": 386.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-21T06:23:01Z",
+    "average_watts": 167.0,
+    "average_speed": 4.203,
+    "distance": 3261.5,
+    "moving_time": 776,
+    "total_elevation_gain": 29.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-22T13:05:09Z",
+    "average_watts": 155.6,
+    "average_speed": 7.383,
+    "distance": 26335.1,
+    "moving_time": 3567,
+    "total_elevation_gain": 364.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-23T13:44:43Z",
+    "average_watts": 149.8,
+    "average_speed": 5.64,
+    "distance": 5780.9,
+    "moving_time": 1025,
+    "total_elevation_gain": 41.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2023-12-30T07:41:49Z",
+    "average_watts": 175.4,
+    "average_speed": 6.705,
+    "distance": 64578.2,
+    "moving_time": 9631,
+    "total_elevation_gain": 736.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-02T15:40:02Z",
+    "average_watts": 148.4,
+    "average_speed": 6.435,
+    "distance": 39854.7,
+    "moving_time": 6193,
+    "total_elevation_gain": 301.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-03T06:58:49Z",
+    "average_watts": 161.0,
+    "average_speed": 6.907,
+    "distance": 36421.0,
+    "moving_time": 5273,
+    "total_elevation_gain": 352.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-09T12:34:25Z",
+    "average_watts": 153.2,
+    "average_speed": 4.905,
+    "distance": 4188.7,
+    "moving_time": 854,
+    "total_elevation_gain": 51.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-12T11:28:07Z",
+    "average_watts": 176.3,
+    "average_speed": 9.253,
+    "distance": 19644.4,
+    "moving_time": 2123,
+    "total_elevation_gain": 219.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-13T18:30:43Z",
+    "average_watts": 158.7,
+    "average_speed": 7.684,
+    "distance": 20309.8,
+    "moving_time": 2643,
+    "total_elevation_gain": 268.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-16T09:09:08Z",
+    "average_watts": 158.8,
+    "average_speed": 4.635,
+    "distance": 6571.8,
+    "moving_time": 1418,
+    "total_elevation_gain": 36.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-18T16:17:46Z",
+    "average_watts": 186.1,
+    "average_speed": 5.75,
+    "distance": 97443.0,
+    "moving_time": 16946,
+    "total_elevation_gain": 572.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-20T16:46:54Z",
+    "average_watts": 160.0,
+    "average_speed": 8.568,
+    "distance": 22440.6,
+    "moving_time": 2619,
+    "total_elevation_gain": 264.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-21T07:47:30Z",
+    "average_watts": 164.4,
+    "average_speed": 5.539,
+    "distance": 24337.8,
+    "moving_time": 4394,
+    "total_elevation_gain": 251.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-22T19:01:37Z",
+    "average_watts": 160.8,
+    "average_speed": 4.351,
+    "distance": 6687.9,
+    "moving_time": 1537,
+    "total_elevation_gain": 87.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-23T09:08:54Z",
+    "average_watts": 179.6,
+    "average_speed": 4.723,
+    "distance": 6385.2,
+    "moving_time": 1352,
+    "total_elevation_gain": 51.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-24T13:34:17Z",
+    "average_watts": 150.8,
+    "average_speed": 7.607,
+    "distance": 12681.0,
+    "moving_time": 1667,
+    "total_elevation_gain": 107.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-25T17:25:35Z",
+    "average_watts": 160.0,
+    "average_speed": 5.105,
+    "distance": 82004.1,
+    "moving_time": 16062,
+    "total_elevation_gain": 914.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-27T19:51:07Z",
+    "average_watts": 156.2,
+    "average_speed": 5.545,
+    "distance": 26188.0,
+    "moving_time": 4723,
+    "total_elevation_gain": 165.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-28T16:31:26Z",
+    "average_watts": 174.5,
+    "average_speed": 5.798,
+    "distance": 72673.8,
+    "moving_time": 12534,
+    "total_elevation_gain": 758.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-01-29T16:14:09Z",
+    "average_watts": 161.8,
+    "average_speed": 7.805,
+    "distance": 39923.5,
+    "moving_time": 5115,
+    "total_elevation_gain": 342.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-02T06:21:54Z",
+    "average_watts": 155.9,
+    "average_speed": 5.284,
+    "distance": 5415.9,
+    "moving_time": 1025,
+    "total_elevation_gain": 53.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-03T18:13:12Z",
+    "average_watts": 177.7,
+    "average_speed": 6.7,
+    "distance": 26591.5,
+    "moving_time": 3969,
+    "total_elevation_gain": 216.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-04T11:15:55Z",
+    "average_watts": 166.4,
+    "average_speed": 3.012,
+    "distance": 5638.5,
+    "moving_time": 1872,
+    "total_elevation_gain": 50.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-07T09:21:28Z",
+    "average_watts": 185.2,
+    "average_speed": 3.042,
+    "distance": 7292.4,
+    "moving_time": 2397,
+    "total_elevation_gain": 65.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-10T10:49:58Z",
+    "average_watts": 187.8,
+    "average_speed": 7.858,
+    "distance": 21751.2,
+    "moving_time": 2768,
+    "total_elevation_gain": 319.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-11T09:18:26Z",
+    "average_watts": 186.2,
+    "average_speed": 7.921,
+    "distance": 14748.6,
+    "moving_time": 1862,
+    "total_elevation_gain": 169.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-13T18:13:52Z",
+    "average_watts": 153.8,
+    "average_speed": 9.654,
+    "distance": 14510.5,
+    "moving_time": 1503,
+    "total_elevation_gain": 119.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-14T19:56:34Z",
+    "average_watts": 171.3,
+    "average_speed": 5.374,
+    "distance": 61849.8,
+    "moving_time": 11509,
+    "total_elevation_gain": 327.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-15T07:40:17Z",
+    "average_watts": 150.8,
+    "average_speed": 5.344,
+    "distance": 4654.2,
+    "moving_time": 871,
+    "total_elevation_gain": 37.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-19T11:06:07Z",
+    "average_watts": 162.3,
+    "average_speed": 6.245,
+    "distance": 27769.8,
+    "moving_time": 4447,
+    "total_elevation_gain": 331.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-22T17:18:12Z",
+    "average_watts": 160.3,
+    "average_speed": 5.715,
+    "distance": 4480.6,
+    "moving_time": 784,
+    "total_elevation_gain": 45.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-24T10:18:35Z",
+    "average_watts": 179.3,
+    "average_speed": 8.744,
+    "distance": 23625.9,
+    "moving_time": 2702,
+    "total_elevation_gain": 298.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-25T08:35:04Z",
+    "average_watts": 158.6,
+    "average_speed": 5.797,
+    "distance": 53518.3,
+    "moving_time": 9232,
+    "total_elevation_gain": 373.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-26T10:13:32Z",
+    "average_watts": 160.7,
+    "average_speed": 5.867,
+    "distance": 5016.2,
+    "moving_time": 855,
+    "total_elevation_gain": 47.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-02-28T09:38:47Z",
+    "average_watts": 158.8,
+    "average_speed": 6.837,
+    "distance": 35430.9,
+    "moving_time": 5182,
+    "total_elevation_gain": 446.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-01T14:22:42Z",
+    "average_watts": 161.4,
+    "average_speed": 9.141,
+    "distance": 13694.0,
+    "moving_time": 1498,
+    "total_elevation_gain": 148.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-04T06:30:46Z",
+    "average_watts": 184.8,
+    "average_speed": 7.572,
+    "distance": 34913.2,
+    "moving_time": 4611,
+    "total_elevation_gain": 201.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-07T15:33:50Z",
+    "average_watts": 160.0,
+    "average_speed": 6.447,
+    "distance": 99521.6,
+    "moving_time": 15436,
+    "total_elevation_gain": 1159.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-08T08:20:33Z",
+    "average_watts": 176.8,
+    "average_speed": 4.503,
+    "distance": 4093.5,
+    "moving_time": 909,
+    "total_elevation_gain": 56.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-11T15:57:16Z",
+    "average_watts": 171.6,
+    "average_speed": 5.435,
+    "distance": 30234.4,
+    "moving_time": 5563,
+    "total_elevation_gain": 367.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-15T17:01:11Z",
+    "average_watts": 152.0,
+    "average_speed": 6.094,
+    "distance": 61362.9,
+    "moving_time": 10069,
+    "total_elevation_gain": 819.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-17T09:15:24Z",
+    "average_watts": 188.7,
+    "average_speed": 6.505,
+    "distance": 78903.7,
+    "moving_time": 12129,
+    "total_elevation_gain": 834.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-20T11:21:40Z",
+    "average_watts": 160.0,
+    "average_speed": 5.845,
+    "distance": 79118.7,
+    "moving_time": 13536,
+    "total_elevation_gain": 1071.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-22T16:36:09Z",
+    "average_watts": 152.6,
+    "average_speed": 6.593,
+    "distance": 96015.6,
+    "moving_time": 14563,
+    "total_elevation_gain": 616.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-26T07:15:44Z",
+    "average_watts": 165.0,
+    "average_speed": 7.959,
+    "distance": 23947.5,
+    "moving_time": 3009,
+    "total_elevation_gain": 284.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-29T13:38:51Z",
+    "average_watts": 166.4,
+    "average_speed": 3.516,
+    "distance": 4089.1,
+    "moving_time": 1163,
+    "total_elevation_gain": 21.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-30T09:22:19Z",
+    "average_watts": 189.5,
+    "average_speed": 6.28,
+    "distance": 71735.2,
+    "moving_time": 11422,
+    "total_elevation_gain": 589.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-03-31T15:27:25Z",
+    "average_watts": 189.0,
+    "average_speed": 6.389,
+    "distance": 59101.6,
+    "moving_time": 9251,
+    "total_elevation_gain": 830.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-01T14:35:54Z",
+    "average_watts": 185.6,
+    "average_speed": 8.026,
+    "distance": 16028.3,
+    "moving_time": 1997,
+    "total_elevation_gain": 103.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-02T13:06:29Z",
+    "average_watts": 155.3,
+    "average_speed": 5.124,
+    "distance": 25076.6,
+    "moving_time": 4894,
+    "total_elevation_gain": 147.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-06T08:18:47Z",
+    "average_watts": 150.7,
+    "average_speed": 9.862,
+    "distance": 17021.1,
+    "moving_time": 1726,
+    "total_elevation_gain": 168.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-07T15:30:01Z",
+    "average_watts": 169.3,
+    "average_speed": 7.91,
+    "distance": 16580.3,
+    "moving_time": 2096,
+    "total_elevation_gain": 190.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-10T13:28:17Z",
+    "average_watts": 164.8,
+    "average_speed": 5.482,
+    "distance": 52078.4,
+    "moving_time": 9500,
+    "total_elevation_gain": 366.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-11T17:50:45Z",
+    "average_watts": 163.4,
+    "average_speed": 5.092,
+    "distance": 60029.7,
+    "moving_time": 11788,
+    "total_elevation_gain": 774.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-12T17:38:03Z",
+    "average_watts": 159.0,
+    "average_speed": 4.481,
+    "distance": 7088.3,
+    "moving_time": 1582,
+    "total_elevation_gain": 50.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-13T16:47:30Z",
+    "average_watts": 170.6,
+    "average_speed": 5.76,
+    "distance": 96301.0,
+    "moving_time": 16720,
+    "total_elevation_gain": 1155.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-15T06:54:13Z",
+    "average_watts": 168.1,
+    "average_speed": 9.105,
+    "distance": 22543.6,
+    "moving_time": 2476,
+    "total_elevation_gain": 284.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-17T14:27:15Z",
+    "average_watts": 176.4,
+    "average_speed": 5.321,
+    "distance": 83463.8,
+    "moving_time": 15686,
+    "total_elevation_gain": 695.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-18T10:27:51Z",
+    "average_watts": 158.1,
+    "average_speed": 5.787,
+    "distance": 28348.4,
+    "moving_time": 4899,
+    "total_elevation_gain": 366.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-19T17:51:01Z",
+    "average_watts": 168.4,
+    "average_speed": 3.22,
+    "distance": 3516.8,
+    "moving_time": 1092,
+    "total_elevation_gain": 28.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-20T17:59:29Z",
+    "average_watts": 157.4,
+    "average_speed": 5.017,
+    "distance": 20708.4,
+    "moving_time": 4128,
+    "total_elevation_gain": 133.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-21T09:00:14Z",
+    "average_watts": 189.4,
+    "average_speed": 5.986,
+    "distance": 21728.4,
+    "moving_time": 3630,
+    "total_elevation_gain": 163.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-22T15:16:45Z",
+    "average_watts": 166.6,
+    "average_speed": 6.853,
+    "distance": 28975.1,
+    "moving_time": 4228,
+    "total_elevation_gain": 395.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-23T08:21:01Z",
+    "average_watts": 155.0,
+    "average_speed": 6.063,
+    "distance": 29122.6,
+    "moving_time": 4803,
+    "total_elevation_gain": 326.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-24T10:34:22Z",
+    "average_watts": 189.5,
+    "average_speed": 7.705,
+    "distance": 22968.8,
+    "moving_time": 2981,
+    "total_elevation_gain": 142.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-26T06:24:42Z",
+    "average_watts": 155.7,
+    "average_speed": 3.226,
+    "distance": 7397.8,
+    "moving_time": 2293,
+    "total_elevation_gain": 83.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-28T09:27:44Z",
+    "average_watts": 163.7,
+    "average_speed": 7.959,
+    "distance": 23024.2,
+    "moving_time": 2893,
+    "total_elevation_gain": 295.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-04-30T14:28:00Z",
+    "average_watts": 171.0,
+    "average_speed": 6.56,
+    "distance": 83143.7,
+    "moving_time": 12674,
+    "total_elevation_gain": 760.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-01T15:57:49Z",
+    "average_watts": 158.0,
+    "average_speed": 7.81,
+    "distance": 28240.1,
+    "moving_time": 3616,
+    "total_elevation_gain": 193.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-05T10:57:17Z",
+    "average_watts": 188.0,
+    "average_speed": 3.069,
+    "distance": 6534.6,
+    "moving_time": 2129,
+    "total_elevation_gain": 83.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-07T07:01:01Z",
+    "average_watts": 163.0,
+    "average_speed": 8.822,
+    "distance": 12412.3,
+    "moving_time": 1407,
+    "total_elevation_gain": 104.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-08T18:41:25Z",
+    "average_watts": 182.9,
+    "average_speed": 8.595,
+    "distance": 15642.7,
+    "moving_time": 1820,
+    "total_elevation_gain": 162.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-12T08:18:48Z",
+    "average_watts": 188.8,
+    "average_speed": 8.58,
+    "distance": 16010.5,
+    "moving_time": 1866,
+    "total_elevation_gain": 175.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-16T08:49:42Z",
+    "average_watts": 184.5,
+    "average_speed": 6.731,
+    "distance": 88589.2,
+    "moving_time": 13161,
+    "total_elevation_gain": 1228.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-17T09:10:14Z",
+    "average_watts": 173.6,
+    "average_speed": 3.672,
+    "distance": 5831.5,
+    "moving_time": 1588,
+    "total_elevation_gain": 56.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-24T19:12:55Z",
+    "average_watts": 188.9,
+    "average_speed": 7.506,
+    "distance": 25653.9,
+    "moving_time": 3418,
+    "total_elevation_gain": 264.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-05-27T19:15:42Z",
+    "average_watts": 179.4,
+    "average_speed": 6.624,
+    "distance": 63337.5,
+    "moving_time": 9562,
+    "total_elevation_gain": 544.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-01T06:54:14Z",
+    "average_watts": 184.4,
+    "average_speed": 9.298,
+    "distance": 12469.0,
+    "moving_time": 1341,
+    "total_elevation_gain": 166.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-04T09:10:05Z",
+    "average_watts": 155.7,
+    "average_speed": 6.644,
+    "distance": 22470.3,
+    "moving_time": 3382,
+    "total_elevation_gain": 162.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-06T17:54:16Z",
+    "average_watts": 172.2,
+    "average_speed": 5.821,
+    "distance": 3585.7,
+    "moving_time": 616,
+    "total_elevation_gain": 32.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-07T19:34:58Z",
+    "average_watts": 169.2,
+    "average_speed": 9.797,
+    "distance": 21337.1,
+    "moving_time": 2178,
+    "total_elevation_gain": 301.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-08T12:17:41Z",
+    "average_watts": 158.6,
+    "average_speed": 8.18,
+    "distance": 22674.1,
+    "moving_time": 2772,
+    "total_elevation_gain": 117.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-10T07:20:21Z",
+    "average_watts": 174.6,
+    "average_speed": 7.389,
+    "distance": 17829.0,
+    "moving_time": 2413,
+    "total_elevation_gain": 210.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-11T07:49:19Z",
+    "average_watts": 162.2,
+    "average_speed": 6.326,
+    "distance": 87091.9,
+    "moving_time": 13768,
+    "total_elevation_gain": 711.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-12T08:46:29Z",
+    "average_watts": 189.5,
+    "average_speed": 4.238,
+    "distance": 4124.0,
+    "moving_time": 973,
+    "total_elevation_gain": 61.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-14T15:36:03Z",
+    "average_watts": 154.9,
+    "average_speed": 5.354,
+    "distance": 7474.0,
+    "moving_time": 1396,
+    "total_elevation_gain": 109.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-15T12:53:23Z",
+    "average_watts": 154.0,
+    "average_speed": 7.094,
+    "distance": 25290.1,
+    "moving_time": 3565,
+    "total_elevation_gain": 248.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-16T14:16:27Z",
+    "average_watts": 155.8,
+    "average_speed": 6.832,
+    "distance": 59681.3,
+    "moving_time": 8735,
+    "total_elevation_gain": 844.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-17T07:07:43Z",
+    "average_watts": 170.7,
+    "average_speed": 5.175,
+    "distance": 54173.7,
+    "moving_time": 10468,
+    "total_elevation_gain": 375.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-21T18:40:12Z",
+    "average_watts": 156.6,
+    "average_speed": 6.097,
+    "distance": 25370.8,
+    "moving_time": 4161,
+    "total_elevation_gain": 168.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-23T07:31:37Z",
+    "average_watts": 151.3,
+    "average_speed": 5.218,
+    "distance": 5149.9,
+    "moving_time": 987,
+    "total_elevation_gain": 61.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-25T13:10:24Z",
+    "average_watts": 187.2,
+    "average_speed": 6.342,
+    "distance": 78456.0,
+    "moving_time": 12370,
+    "total_elevation_gain": 539.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-26T18:20:55Z",
+    "average_watts": 158.7,
+    "average_speed": 3.737,
+    "distance": 4517.7,
+    "moving_time": 1209,
+    "total_elevation_gain": 63.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-28T08:27:33Z",
+    "average_watts": 183.4,
+    "average_speed": 5.078,
+    "distance": 73959.4,
+    "moving_time": 14565,
+    "total_elevation_gain": 1018.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-29T08:51:11Z",
+    "average_watts": 169.6,
+    "average_speed": 7.475,
+    "distance": 31439.1,
+    "moving_time": 4206,
+    "total_elevation_gain": 450.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-06-30T12:41:54Z",
+    "average_watts": 151.4,
+    "average_speed": 5.166,
+    "distance": 57850.3,
+    "moving_time": 11198,
+    "total_elevation_gain": 510.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-01T06:49:58Z",
+    "average_watts": 166.7,
+    "average_speed": 7.701,
+    "distance": 19374.9,
+    "moving_time": 2516,
+    "total_elevation_gain": 279.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-03T07:01:09Z",
+    "average_watts": 163.9,
+    "average_speed": 5.589,
+    "distance": 58350.6,
+    "moving_time": 10440,
+    "total_elevation_gain": 383.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-04T08:03:46Z",
+    "average_watts": 179.7,
+    "average_speed": 8.844,
+    "distance": 14991.3,
+    "moving_time": 1695,
+    "total_elevation_gain": 188.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-12T19:19:03Z",
+    "average_watts": 152.1,
+    "average_speed": 6.782,
+    "distance": 98911.1,
+    "moving_time": 14585,
+    "total_elevation_gain": 1107.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-15T19:01:01Z",
+    "average_watts": 162.4,
+    "average_speed": 5.259,
+    "distance": 5343.6,
+    "moving_time": 1016,
+    "total_elevation_gain": 27.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-17T12:49:19Z",
+    "average_watts": 160.0,
+    "average_speed": 4.918,
+    "distance": 4805.3,
+    "moving_time": 977,
+    "total_elevation_gain": 48.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-18T15:43:01Z",
+    "average_watts": 165.5,
+    "average_speed": 7.478,
+    "distance": 16712.8,
+    "moving_time": 2235,
+    "total_elevation_gain": 141.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-19T18:25:23Z",
+    "average_watts": 156.5,
+    "average_speed": 7.645,
+    "distance": 11582.3,
+    "moving_time": 1515,
+    "total_elevation_gain": 114.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-20T17:11:21Z",
+    "average_watts": 159.8,
+    "average_speed": 6.284,
+    "distance": 67285.2,
+    "moving_time": 10708,
+    "total_elevation_gain": 849.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-21T18:06:27Z",
+    "average_watts": 183.4,
+    "average_speed": 6.852,
+    "distance": 82095.9,
+    "moving_time": 11981,
+    "total_elevation_gain": 1154.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-22T13:51:14Z",
+    "average_watts": 171.6,
+    "average_speed": 3.723,
+    "distance": 4054.3,
+    "moving_time": 1089,
+    "total_elevation_gain": 22.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-23T18:03:46Z",
+    "average_watts": 183.7,
+    "average_speed": 5.437,
+    "distance": 90392.4,
+    "moving_time": 16626,
+    "total_elevation_gain": 1239.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-25T11:22:50Z",
+    "average_watts": 166.9,
+    "average_speed": 6.308,
+    "distance": 29805.0,
+    "moving_time": 4725,
+    "total_elevation_gain": 202.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-28T16:10:39Z",
+    "average_watts": 174.1,
+    "average_speed": 8.679,
+    "distance": 17965.5,
+    "moving_time": 2070,
+    "total_elevation_gain": 164.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-07-30T11:25:52Z",
+    "average_watts": 167.2,
+    "average_speed": 5.151,
+    "distance": 3389.6,
+    "moving_time": 658,
+    "total_elevation_gain": 47.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-01T10:16:00Z",
+    "average_watts": 166.8,
+    "average_speed": 5.909,
+    "distance": 6204.3,
+    "moving_time": 1050,
+    "total_elevation_gain": 49.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-04T06:59:44Z",
+    "average_watts": 183.7,
+    "average_speed": 5.72,
+    "distance": 51067.1,
+    "moving_time": 8928,
+    "total_elevation_gain": 543.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-06T17:11:17Z",
+    "average_watts": 158.5,
+    "average_speed": 3.323,
+    "distance": 6176.6,
+    "moving_time": 1859,
+    "total_elevation_gain": 33.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-07T12:12:45Z",
+    "average_watts": 163.6,
+    "average_speed": 5.503,
+    "distance": 96111.5,
+    "moving_time": 17464,
+    "total_elevation_gain": 649.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-09T06:23:39Z",
+    "average_watts": 186.1,
+    "average_speed": 5.293,
+    "distance": 81324.2,
+    "moving_time": 15365,
+    "total_elevation_gain": 805.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-10T09:26:24Z",
+    "average_watts": 189.4,
+    "average_speed": 7.398,
+    "distance": 19381.7,
+    "moving_time": 2620,
+    "total_elevation_gain": 182.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-12T15:40:20Z",
+    "average_watts": 166.6,
+    "average_speed": 5.67,
+    "distance": 39120.6,
+    "moving_time": 6900,
+    "total_elevation_gain": 356.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-14T09:02:05Z",
+    "average_watts": 178.9,
+    "average_speed": 5.698,
+    "distance": 6774.5,
+    "moving_time": 1189,
+    "total_elevation_gain": 98.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-15T14:17:06Z",
+    "average_watts": 191.0,
+    "average_speed": 9.431,
+    "distance": 12788.8,
+    "moving_time": 1356,
+    "total_elevation_gain": 82.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-18T14:32:57Z",
+    "average_watts": 190.2,
+    "average_speed": 6.403,
+    "distance": 70703.6,
+    "moving_time": 11043,
+    "total_elevation_gain": 358.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-20T06:20:27Z",
+    "average_watts": 170.5,
+    "average_speed": 9.605,
+    "distance": 14465.3,
+    "moving_time": 1506,
+    "total_elevation_gain": 154.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-21T10:14:08Z",
+    "average_watts": 156.2,
+    "average_speed": 9.869,
+    "distance": 22284.6,
+    "moving_time": 2258,
+    "total_elevation_gain": 227.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-22T09:06:37Z",
+    "average_watts": 160.6,
+    "average_speed": 6.893,
+    "distance": 77920.2,
+    "moving_time": 11305,
+    "total_elevation_gain": 1111.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-25T14:57:38Z",
+    "average_watts": 188.0,
+    "average_speed": 4.14,
+    "distance": 3585.6,
+    "moving_time": 866,
+    "total_elevation_gain": 18.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-27T17:23:40Z",
+    "average_watts": 172.7,
+    "average_speed": 5.41,
+    "distance": 26586.4,
+    "moving_time": 4914,
+    "total_elevation_gain": 377.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-29T18:47:33Z",
+    "average_watts": 175.8,
+    "average_speed": 6.754,
+    "distance": 22821.7,
+    "moving_time": 3379,
+    "total_elevation_gain": 326.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-08-30T06:15:36Z",
+    "average_watts": 189.4,
+    "average_speed": 3.262,
+    "distance": 3741.2,
+    "moving_time": 1147,
+    "total_elevation_gain": 28.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-02T17:18:24Z",
+    "average_watts": 187.3,
+    "average_speed": 6.952,
+    "distance": 33346.6,
+    "moving_time": 4797,
+    "total_elevation_gain": 327.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-03T17:35:14Z",
+    "average_watts": 164.6,
+    "average_speed": 3.561,
+    "distance": 3967.1,
+    "moving_time": 1114,
+    "total_elevation_gain": 24.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-04T08:32:56Z",
+    "average_watts": 178.4,
+    "average_speed": 7.924,
+    "distance": 30751.7,
+    "moving_time": 3881,
+    "total_elevation_gain": 256.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-05T15:07:51Z",
+    "average_watts": 152.1,
+    "average_speed": 4.497,
+    "distance": 4069.4,
+    "moving_time": 905,
+    "total_elevation_gain": 58.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-06T15:44:26Z",
+    "average_watts": 168.8,
+    "average_speed": 5.451,
+    "distance": 24891.0,
+    "moving_time": 4566,
+    "total_elevation_gain": 318.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-07T09:43:56Z",
+    "average_watts": 166.3,
+    "average_speed": 5.479,
+    "distance": 20383.3,
+    "moving_time": 3720,
+    "total_elevation_gain": 231.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-09T08:55:18Z",
+    "average_watts": 174.3,
+    "average_speed": 5.105,
+    "distance": 56924.2,
+    "moving_time": 11150,
+    "total_elevation_gain": 773.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-11T07:19:27Z",
+    "average_watts": 184.1,
+    "average_speed": 6.492,
+    "distance": 20951.0,
+    "moving_time": 3227,
+    "total_elevation_gain": 295.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-15T09:37:46Z",
+    "average_watts": 186.0,
+    "average_speed": 5.314,
+    "distance": 28068.7,
+    "moving_time": 5282,
+    "total_elevation_gain": 163.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-17T18:43:04Z",
+    "average_watts": 172.9,
+    "average_speed": 5.259,
+    "distance": 90757.3,
+    "moving_time": 17257,
+    "total_elevation_gain": 664.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-20T13:00:21Z",
+    "average_watts": 187.2,
+    "average_speed": 5.466,
+    "distance": 3744.1,
+    "moving_time": 685,
+    "total_elevation_gain": 42.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-21T16:44:40Z",
+    "average_watts": 172.2,
+    "average_speed": 7.015,
+    "distance": 14416.8,
+    "moving_time": 2055,
+    "total_elevation_gain": 121.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-23T06:57:19Z",
+    "average_watts": 156.9,
+    "average_speed": 7.18,
+    "distance": 27851.5,
+    "moving_time": 3879,
+    "total_elevation_gain": 316.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-24T16:09:47Z",
+    "average_watts": 155.5,
+    "average_speed": 3.828,
+    "distance": 3154.3,
+    "moving_time": 824,
+    "total_elevation_gain": 34.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-28T11:21:18Z",
+    "average_watts": 182.7,
+    "average_speed": 4.216,
+    "distance": 4186.9,
+    "moving_time": 993,
+    "total_elevation_gain": 25.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-09-29T13:31:33Z",
+    "average_watts": 187.0,
+    "average_speed": 5.598,
+    "distance": 27559.3,
+    "moving_time": 4923,
+    "total_elevation_gain": 351.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-01T09:11:28Z",
+    "average_watts": 183.2,
+    "average_speed": 6.474,
+    "distance": 62347.3,
+    "moving_time": 9631,
+    "total_elevation_gain": 758.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-02T07:24:31Z",
+    "average_watts": 190.4,
+    "average_speed": 8.829,
+    "distance": 18902.7,
+    "moving_time": 2141,
+    "total_elevation_gain": 245.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-03T14:50:37Z",
+    "average_watts": 157.4,
+    "average_speed": 6.249,
+    "distance": 95770.6,
+    "moving_time": 15325,
+    "total_elevation_gain": 555.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-04T17:53:07Z",
+    "average_watts": 189.4,
+    "average_speed": 6.357,
+    "distance": 27959.1,
+    "moving_time": 4398,
+    "total_elevation_gain": 367.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-08T11:35:00Z",
+    "average_watts": 160.0,
+    "average_speed": 5.364,
+    "distance": 98267.1,
+    "moving_time": 18319,
+    "total_elevation_gain": 1267.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-10T10:34:57Z",
+    "average_watts": 162.9,
+    "average_speed": 8.038,
+    "distance": 16581.7,
+    "moving_time": 2063,
+    "total_elevation_gain": 242.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-13T09:51:04Z",
+    "average_watts": 190.1,
+    "average_speed": 7.127,
+    "distance": 16185.5,
+    "moving_time": 2271,
+    "total_elevation_gain": 238.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-14T07:22:45Z",
+    "average_watts": 185.5,
+    "average_speed": 5.886,
+    "distance": 5679.7,
+    "moving_time": 965,
+    "total_elevation_gain": 46.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-16T10:44:35Z",
+    "average_watts": 153.8,
+    "average_speed": 6.505,
+    "distance": 85351.5,
+    "moving_time": 13121,
+    "total_elevation_gain": 1009.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-18T14:06:23Z",
+    "average_watts": 157.8,
+    "average_speed": 7.87,
+    "distance": 34676.7,
+    "moving_time": 4406,
+    "total_elevation_gain": 373.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-20T18:11:33Z",
+    "average_watts": 186.3,
+    "average_speed": 5.37,
+    "distance": 55013.8,
+    "moving_time": 10244,
+    "total_elevation_gain": 279.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-21T13:14:06Z",
+    "average_watts": 163.6,
+    "average_speed": 5.841,
+    "distance": 3703.3,
+    "moving_time": 634,
+    "total_elevation_gain": 26.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-22T18:30:28Z",
+    "average_watts": 189.7,
+    "average_speed": 8.695,
+    "distance": 20208.1,
+    "moving_time": 2324,
+    "total_elevation_gain": 186.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-24T07:24:11Z",
+    "average_watts": 173.3,
+    "average_speed": 6.403,
+    "distance": 97700.4,
+    "moving_time": 15258,
+    "total_elevation_gain": 1434.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-25T07:27:03Z",
+    "average_watts": 170.1,
+    "average_speed": 5.345,
+    "distance": 7413.8,
+    "moving_time": 1387,
+    "total_elevation_gain": 49.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-26T07:06:45Z",
+    "average_watts": 168.6,
+    "average_speed": 7.923,
+    "distance": 12145.9,
+    "moving_time": 1533,
+    "total_elevation_gain": 179.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-27T17:13:21Z",
+    "average_watts": 163.0,
+    "average_speed": 7.989,
+    "distance": 29656.5,
+    "moving_time": 3712,
+    "total_elevation_gain": 299.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-28T07:24:45Z",
+    "average_watts": 155.6,
+    "average_speed": 7.078,
+    "distance": 26621.3,
+    "moving_time": 3761,
+    "total_elevation_gain": 270.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-29T08:25:16Z",
+    "average_watts": 192.3,
+    "average_speed": 4.438,
+    "distance": 5774.2,
+    "moving_time": 1301,
+    "total_elevation_gain": 51.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-10-31T17:50:53Z",
+    "average_watts": 158.2,
+    "average_speed": 9.313,
+    "distance": 16540.1,
+    "moving_time": 1776,
+    "total_elevation_gain": 140.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-02T10:18:50Z",
+    "average_watts": 184.7,
+    "average_speed": 9.674,
+    "distance": 21369.5,
+    "moving_time": 2209,
+    "total_elevation_gain": 205.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-04T11:27:01Z",
+    "average_watts": 172.5,
+    "average_speed": 6.582,
+    "distance": 81871.3,
+    "moving_time": 12438,
+    "total_elevation_gain": 973.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-06T19:33:27Z",
+    "average_watts": 172.1,
+    "average_speed": 7.023,
+    "distance": 39820.4,
+    "moving_time": 5670,
+    "total_elevation_gain": 400.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-08T12:20:25Z",
+    "average_watts": 169.7,
+    "average_speed": 6.001,
+    "distance": 37029.2,
+    "moving_time": 6170,
+    "total_elevation_gain": 388.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-13T12:55:35Z",
+    "average_watts": 165.1,
+    "average_speed": 8.295,
+    "distance": 16184.1,
+    "moving_time": 1951,
+    "total_elevation_gain": 219.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-15T19:39:55Z",
+    "average_watts": 180.5,
+    "average_speed": 7.365,
+    "distance": 18345.9,
+    "moving_time": 2491,
+    "total_elevation_gain": 263.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-16T12:18:46Z",
+    "average_watts": 156.6,
+    "average_speed": 5.385,
+    "distance": 5035.0,
+    "moving_time": 935,
+    "total_elevation_gain": 72.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-18T10:00:37Z",
+    "average_watts": 155.4,
+    "average_speed": 5.692,
+    "distance": 5276.6,
+    "moving_time": 927,
+    "total_elevation_gain": 36.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-20T10:58:42Z",
+    "average_watts": 154.9,
+    "average_speed": 8.688,
+    "distance": 24709.7,
+    "moving_time": 2844,
+    "total_elevation_gain": 165.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-21T14:55:28Z",
+    "average_watts": 163.2,
+    "average_speed": 5.358,
+    "distance": 26484.0,
+    "moving_time": 4943,
+    "total_elevation_gain": 359.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-22T18:57:29Z",
+    "average_watts": 181.1,
+    "average_speed": 3.308,
+    "distance": 3995.9,
+    "moving_time": 1208,
+    "total_elevation_gain": 46.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-23T18:42:21Z",
+    "average_watts": 169.3,
+    "average_speed": 6.704,
+    "distance": 20689.3,
+    "moving_time": 3086,
+    "total_elevation_gain": 171.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-25T13:44:54Z",
+    "average_watts": 164.8,
+    "average_speed": 6.763,
+    "distance": 61351.0,
+    "moving_time": 9072,
+    "total_elevation_gain": 905.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-27T12:14:24Z",
+    "average_watts": 165.0,
+    "average_speed": 5.538,
+    "distance": 5887.1,
+    "moving_time": 1063,
+    "total_elevation_gain": 37.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-11-30T07:43:16Z",
+    "average_watts": 167.3,
+    "average_speed": 6.237,
+    "distance": 78324.0,
+    "moving_time": 12558,
+    "total_elevation_gain": 1167.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-01T13:25:13Z",
+    "average_watts": 170.3,
+    "average_speed": 5.909,
+    "distance": 4503.0,
+    "moving_time": 762,
+    "total_elevation_gain": 59.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-03T15:06:39Z",
+    "average_watts": 181.5,
+    "average_speed": 6.068,
+    "distance": 83140.7,
+    "moving_time": 13701,
+    "total_elevation_gain": 1172.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-07T13:00:09Z",
+    "average_watts": 163.6,
+    "average_speed": 6.0,
+    "distance": 31871.8,
+    "moving_time": 5312,
+    "total_elevation_gain": 387.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-08T13:45:23Z",
+    "average_watts": 188.7,
+    "average_speed": 7.521,
+    "distance": 13679.9,
+    "moving_time": 1819,
+    "total_elevation_gain": 172.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-10T12:27:52Z",
+    "average_watts": 171.1,
+    "average_speed": 5.244,
+    "distance": 83399.0,
+    "moving_time": 15905,
+    "total_elevation_gain": 815.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-13T07:21:25Z",
+    "average_watts": 156.3,
+    "average_speed": 6.582,
+    "distance": 37476.6,
+    "moving_time": 5694,
+    "total_elevation_gain": 317.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-14T16:45:51Z",
+    "average_watts": 190.9,
+    "average_speed": 6.257,
+    "distance": 67592.4,
+    "moving_time": 10802,
+    "total_elevation_gain": 688.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-16T06:07:03Z",
+    "average_watts": 155.2,
+    "average_speed": 5.121,
+    "distance": 4787.7,
+    "moving_time": 935,
+    "total_elevation_gain": 28.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-21T10:50:32Z",
+    "average_watts": 186.4,
+    "average_speed": 4.997,
+    "distance": 4322.3,
+    "moving_time": 865,
+    "total_elevation_gain": 49.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-24T10:25:45Z",
+    "average_watts": 161.6,
+    "average_speed": 7.74,
+    "distance": 25689.9,
+    "moving_time": 3319,
+    "total_elevation_gain": 237.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-26T10:40:05Z",
+    "average_watts": 192.1,
+    "average_speed": 7.765,
+    "distance": 21967.4,
+    "moving_time": 2829,
+    "total_elevation_gain": 151.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-29T08:32:54Z",
+    "average_watts": 188.9,
+    "average_speed": 8.02,
+    "distance": 16937.2,
+    "moving_time": 2112,
+    "total_elevation_gain": 205.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-01T09:26:09Z",
+    "average_watts": 166.4,
+    "average_speed": 6.686,
+    "distance": 26843.7,
+    "moving_time": 4015,
+    "total_elevation_gain": 357.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-02T10:15:21Z",
+    "average_watts": 164.6,
+    "average_speed": 7.504,
+    "distance": 10265.4,
+    "moving_time": 1368,
+    "total_elevation_gain": 95.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-03T06:02:32Z",
+    "average_watts": 180.7,
+    "average_speed": 5.305,
+    "distance": 21580.6,
+    "moving_time": 4068,
+    "total_elevation_gain": 294.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-05T17:46:54Z",
+    "average_watts": 155.7,
+    "average_speed": 7.681,
+    "distance": 15400.9,
+    "moving_time": 2005,
+    "total_elevation_gain": 188.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-07T06:16:41Z",
+    "average_watts": 188.8,
+    "average_speed": 8.492,
+    "distance": 24864.6,
+    "moving_time": 2928,
+    "total_elevation_gain": 327.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-09T18:48:46Z",
+    "average_watts": 188.1,
+    "average_speed": 5.692,
+    "distance": 84071.1,
+    "moving_time": 14769,
+    "total_elevation_gain": 1083.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-10T06:53:42Z",
+    "average_watts": 174.3,
+    "average_speed": 6.439,
+    "distance": 96649.5,
+    "moving_time": 15010,
+    "total_elevation_gain": 665.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-19T19:49:36Z",
+    "average_watts": 191.2,
+    "average_speed": 4.349,
+    "distance": 3822.6,
+    "moving_time": 879,
+    "total_elevation_gain": 30.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-21T13:45:52Z",
+    "average_watts": 167.1,
+    "average_speed": 6.687,
+    "distance": 90018.3,
+    "moving_time": 13462,
+    "total_elevation_gain": 472.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-22T18:48:57Z",
+    "average_watts": 164.7,
+    "average_speed": 8.847,
+    "distance": 22240.5,
+    "moving_time": 2514,
+    "total_elevation_gain": 160.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-24T15:39:28Z",
+    "average_watts": 190.8,
+    "average_speed": 5.079,
+    "distance": 32844.3,
+    "moving_time": 6467,
+    "total_elevation_gain": 175.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-27T17:01:10Z",
+    "average_watts": 159.9,
+    "average_speed": 5.476,
+    "distance": 3072.3,
+    "moving_time": 561,
+    "total_elevation_gain": 37.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-29T17:29:21Z",
+    "average_watts": 185.5,
+    "average_speed": 6.916,
+    "distance": 96231.3,
+    "moving_time": 13915,
+    "total_elevation_gain": 904.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-30T17:14:25Z",
+    "average_watts": 163.8,
+    "average_speed": 6.51,
+    "distance": 74295.6,
+    "moving_time": 11412,
+    "total_elevation_gain": 560.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-01-31T19:24:33Z",
+    "average_watts": 189.4,
+    "average_speed": 3.141,
+    "distance": 3923.7,
+    "moving_time": 1249,
+    "total_elevation_gain": 42.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-01T11:02:39Z",
+    "average_watts": 168.9,
+    "average_speed": 9.088,
+    "distance": 21446.9,
+    "moving_time": 2360,
+    "total_elevation_gain": 256.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-03T10:14:14Z",
+    "average_watts": 156.9,
+    "average_speed": 5.84,
+    "distance": 4853.1,
+    "moving_time": 831,
+    "total_elevation_gain": 24.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-04T13:23:26Z",
+    "average_watts": 172.2,
+    "average_speed": 7.524,
+    "distance": 26032.5,
+    "moving_time": 3460,
+    "total_elevation_gain": 269.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-07T14:29:20Z",
+    "average_watts": 167.8,
+    "average_speed": 9.044,
+    "distance": 23296.2,
+    "moving_time": 2576,
+    "total_elevation_gain": 303.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-09T09:46:58Z",
+    "average_watts": 184.1,
+    "average_speed": 5.009,
+    "distance": 4723.8,
+    "moving_time": 943,
+    "total_elevation_gain": 56.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-10T12:17:58Z",
+    "average_watts": 170.5,
+    "average_speed": 7.455,
+    "distance": 19845.8,
+    "moving_time": 2662,
+    "total_elevation_gain": 146.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-13T16:19:41Z",
+    "average_watts": 172.0,
+    "average_speed": 5.179,
+    "distance": 33079.5,
+    "moving_time": 6387,
+    "total_elevation_gain": 472.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-14T16:16:52Z",
+    "average_watts": 187.1,
+    "average_speed": 4.191,
+    "distance": 4354.1,
+    "moving_time": 1039,
+    "total_elevation_gain": 58.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-16T14:07:41Z",
+    "average_watts": 163.8,
+    "average_speed": 3.265,
+    "distance": 4910.5,
+    "moving_time": 1504,
+    "total_elevation_gain": 40.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-18T18:56:57Z",
+    "average_watts": 192.8,
+    "average_speed": 6.278,
+    "distance": 70841.8,
+    "moving_time": 11285,
+    "total_elevation_gain": 936.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-20T06:06:58Z",
+    "average_watts": 177.2,
+    "average_speed": 9.142,
+    "distance": 19153.2,
+    "moving_time": 2095,
+    "total_elevation_gain": 193.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-21T15:55:49Z",
+    "average_watts": 171.6,
+    "average_speed": 5.378,
+    "distance": 35879.7,
+    "moving_time": 6671,
+    "total_elevation_gain": 469.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-23T09:53:56Z",
+    "average_watts": 177.1,
+    "average_speed": 7.329,
+    "distance": 30312.1,
+    "moving_time": 4136,
+    "total_elevation_gain": 260.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-24T10:44:28Z",
+    "average_watts": 186.2,
+    "average_speed": 9.132,
+    "distance": 24730.1,
+    "moving_time": 2708,
+    "total_elevation_gain": 278.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-02-27T16:07:58Z",
+    "average_watts": 192.5,
+    "average_speed": 7.617,
+    "distance": 11440.8,
+    "moving_time": 1502,
+    "total_elevation_gain": 95.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-01T09:21:42Z",
+    "average_watts": 168.5,
+    "average_speed": 6.842,
+    "distance": 95876.1,
+    "moving_time": 14013,
+    "total_elevation_gain": 1209.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-02T13:19:13Z",
+    "average_watts": 178.7,
+    "average_speed": 7.505,
+    "distance": 25222.8,
+    "moving_time": 3361,
+    "total_elevation_gain": 345.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-03T10:41:37Z",
+    "average_watts": 159.3,
+    "average_speed": 7.476,
+    "distance": 19842.3,
+    "moving_time": 2654,
+    "total_elevation_gain": 269.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-04T08:42:20Z",
+    "average_watts": 182.8,
+    "average_speed": 5.723,
+    "distance": 39183.4,
+    "moving_time": 6847,
+    "total_elevation_gain": 359.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-05T13:21:22Z",
+    "average_watts": 180.5,
+    "average_speed": 5.219,
+    "distance": 35805.0,
+    "moving_time": 6860,
+    "total_elevation_gain": 512.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-06T18:44:01Z",
+    "average_watts": 173.5,
+    "average_speed": 5.74,
+    "distance": 58470.7,
+    "moving_time": 10187,
+    "total_elevation_gain": 368.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-07T08:44:49Z",
+    "average_watts": 173.0,
+    "average_speed": 6.004,
+    "distance": 57959.7,
+    "moving_time": 9653,
+    "total_elevation_gain": 461.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-09T18:23:51Z",
+    "average_watts": 186.8,
+    "average_speed": 7.14,
+    "distance": 24919.7,
+    "moving_time": 3490,
+    "total_elevation_gain": 217.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-10T09:02:08Z",
+    "average_watts": 179.3,
+    "average_speed": 6.247,
+    "distance": 74630.5,
+    "moving_time": 11946,
+    "total_elevation_gain": 393.2,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-13T14:36:04Z",
+    "average_watts": 171.0,
+    "average_speed": 9.411,
+    "distance": 17410.7,
+    "moving_time": 1850,
+    "total_elevation_gain": 145.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-16T09:46:27Z",
+    "average_watts": 162.8,
+    "average_speed": 6.046,
+    "distance": 33821.1,
+    "moving_time": 5594,
+    "total_elevation_gain": 494.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-20T06:20:07Z",
+    "average_watts": 165.8,
+    "average_speed": 7.808,
+    "distance": 33620.5,
+    "moving_time": 4306,
+    "total_elevation_gain": 471.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-21T17:59:38Z",
+    "average_watts": 168.2,
+    "average_speed": 7.097,
+    "distance": 11242.0,
+    "moving_time": 1584,
+    "total_elevation_gain": 127.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-25T19:58:07Z",
+    "average_watts": 189.3,
+    "average_speed": 6.847,
+    "distance": 94258.9,
+    "moving_time": 13767,
+    "total_elevation_gain": 1210.5,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-03-30T10:49:24Z",
+    "average_watts": 165.7,
+    "average_speed": 7.094,
+    "distance": 39956.1,
+    "moving_time": 5632,
+    "total_elevation_gain": 242.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-01T08:55:46Z",
+    "average_watts": 172.5,
+    "average_speed": 5.205,
+    "distance": 74742.8,
+    "moving_time": 14361,
+    "total_elevation_gain": 1096.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-02T11:12:25Z",
+    "average_watts": 168.4,
+    "average_speed": 7.485,
+    "distance": 10479.7,
+    "moving_time": 1400,
+    "total_elevation_gain": 99.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-04T07:59:29Z",
+    "average_watts": 192.9,
+    "average_speed": 7.079,
+    "distance": 13280.4,
+    "moving_time": 1876,
+    "total_elevation_gain": 126.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-06T09:10:39Z",
+    "average_watts": 170.3,
+    "average_speed": 5.191,
+    "distance": 97980.3,
+    "moving_time": 18874,
+    "total_elevation_gain": 1186.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-09T14:14:47Z",
+    "average_watts": 182.8,
+    "average_speed": 9.69,
+    "distance": 19650.7,
+    "moving_time": 2028,
+    "total_elevation_gain": 177.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-12T12:24:18Z",
+    "average_watts": 157.9,
+    "average_speed": 3.144,
+    "distance": 7098.3,
+    "moving_time": 2258,
+    "total_elevation_gain": 66.6,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-14T07:07:09Z",
+    "average_watts": 185.1,
+    "average_speed": 6.512,
+    "distance": 89819.4,
+    "moving_time": 13793,
+    "total_elevation_gain": 653.8,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-15T13:40:04Z",
+    "average_watts": 155.5,
+    "average_speed": 8.658,
+    "distance": 18510.9,
+    "moving_time": 2138,
+    "total_elevation_gain": 193.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-16T15:39:15Z",
+    "average_watts": 191.6,
+    "average_speed": 6.922,
+    "distance": 62230.1,
+    "moving_time": 8990,
+    "total_elevation_gain": 649.9,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-17T14:56:17Z",
+    "average_watts": 161.5,
+    "average_speed": 3.806,
+    "distance": 5145.6,
+    "moving_time": 1352,
+    "total_elevation_gain": 56.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-18T11:02:36Z",
+    "average_watts": 191.3,
+    "average_speed": 5.34,
+    "distance": 87296.8,
+    "moving_time": 16349,
+    "total_elevation_gain": 1061.4,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-20T17:36:26Z",
+    "average_watts": 162.4,
+    "average_speed": 7.768,
+    "distance": 24283.5,
+    "moving_time": 3126,
+    "total_elevation_gain": 328.0,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-24T19:58:52Z",
+    "average_watts": 194.6,
+    "average_speed": 4.003,
+    "distance": 6420.9,
+    "moving_time": 1604,
+    "total_elevation_gain": 87.3,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-26T09:05:45Z",
+    "average_watts": 173.9,
+    "average_speed": 5.695,
+    "distance": 52847.2,
+    "moving_time": 9279,
+    "total_elevation_gain": 527.1,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2025-04-28T15:24:50Z",
+    "average_watts": 188.7,
+    "average_speed": 3.989,
+    "distance": 6331.0,
+    "moving_time": 1587,
+    "total_elevation_gain": 84.7,
+    "type": "Ride"
+  },
+  {
+    "start_date": "2024-12-26T11:37:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5174.1,
+    "moving_time": 3568,
+    "total_elevation_gain": 37.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-02-20T17:52:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6520.9,
+    "moving_time": 1653,
+    "total_elevation_gain": 26.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-25T19:28:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1476.9,
+    "moving_time": 1436,
+    "total_elevation_gain": 14.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-01-30T11:53:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7473.2,
+    "moving_time": 2551,
+    "total_elevation_gain": 47.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-16T14:51:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1203.3,
+    "moving_time": 837,
+    "total_elevation_gain": 7.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-05T09:57:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5560.1,
+    "moving_time": 4024,
+    "total_elevation_gain": 29.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-10-23T09:49:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4696.7,
+    "moving_time": 4622,
+    "total_elevation_gain": 15.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-04-01T12:04:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10830.2,
+    "moving_time": 3337,
+    "total_elevation_gain": 71.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-08-15T18:20:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14847.2,
+    "moving_time": 4764,
+    "total_elevation_gain": 73.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-12-12T10:50:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6025.6,
+    "moving_time": 3499,
+    "total_elevation_gain": 57.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-25T18:18:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11682.2,
+    "moving_time": 4623,
+    "total_elevation_gain": 93.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-12-08T16:03:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3118.4,
+    "moving_time": 3321,
+    "total_elevation_gain": 27.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-03-01T15:10:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6094.9,
+    "moving_time": 3820,
+    "total_elevation_gain": 37.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-26T15:19:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8171.6,
+    "moving_time": 3082,
+    "total_elevation_gain": 62.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-03T09:13:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5445.0,
+    "moving_time": 5080,
+    "total_elevation_gain": 12.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-01-02T11:30:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13536.8,
+    "moving_time": 4539,
+    "total_elevation_gain": 108.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-10T17:45:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3517.7,
+    "moving_time": 3025,
+    "total_elevation_gain": 23.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-03T13:13:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1910.1,
+    "moving_time": 1743,
+    "total_elevation_gain": 10.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-09T13:11:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2663.9,
+    "moving_time": 677,
+    "total_elevation_gain": 17.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-03-28T19:48:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6808.6,
+    "moving_time": 3946,
+    "total_elevation_gain": 26.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-24T11:22:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5883.0,
+    "moving_time": 1690,
+    "total_elevation_gain": 19.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-05-03T11:11:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2929.4,
+    "moving_time": 2802,
+    "total_elevation_gain": 22.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-18T18:45:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11515.2,
+    "moving_time": 3874,
+    "total_elevation_gain": 36.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-29T12:28:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1187.6,
+    "moving_time": 856,
+    "total_elevation_gain": 9.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-29T18:13:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13728.1,
+    "moving_time": 3562,
+    "total_elevation_gain": 49.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-08-07T06:05:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8505.9,
+    "moving_time": 2383,
+    "total_elevation_gain": 41.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-03-04T10:21:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6247.3,
+    "moving_time": 2218,
+    "total_elevation_gain": 41.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-30T19:06:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7173.2,
+    "moving_time": 7241,
+    "total_elevation_gain": 24.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-09-21T07:43:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12158.3,
+    "moving_time": 3684,
+    "total_elevation_gain": 103.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-23T14:12:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3485.9,
+    "moving_time": 1274,
+    "total_elevation_gain": 24.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-15T08:09:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6414.7,
+    "moving_time": 3961,
+    "total_elevation_gain": 46.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-02-11T11:07:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6080.4,
+    "moving_time": 2240,
+    "total_elevation_gain": 59.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-06T12:45:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6384.8,
+    "moving_time": 1863,
+    "total_elevation_gain": 31.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-04-13T07:50:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5433.0,
+    "moving_time": 5575,
+    "total_elevation_gain": 52.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-04-20T06:49:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7677.9,
+    "moving_time": 2577,
+    "total_elevation_gain": 49.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-29T15:19:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1154.3,
+    "moving_time": 981,
+    "total_elevation_gain": 9.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-12-22T12:07:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7428.6,
+    "moving_time": 4961,
+    "total_elevation_gain": 57.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-11-25T13:30:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5699.8,
+    "moving_time": 3677,
+    "total_elevation_gain": 52.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-05T08:43:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5931.7,
+    "moving_time": 3936,
+    "total_elevation_gain": 52.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-02-28T06:20:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12799.0,
+    "moving_time": 4744,
+    "total_elevation_gain": 121.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-12-06T09:41:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7584.6,
+    "moving_time": 8177,
+    "total_elevation_gain": 57.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-01-02T19:34:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7924.3,
+    "moving_time": 2240,
+    "total_elevation_gain": 74.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-04-24T08:02:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1478.2,
+    "moving_time": 901,
+    "total_elevation_gain": 5.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-04-06T12:08:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8719.5,
+    "moving_time": 3179,
+    "total_elevation_gain": 54.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-07-17T15:58:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6877.4,
+    "moving_time": 1810,
+    "total_elevation_gain": 61.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-12-04T16:28:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3188.5,
+    "moving_time": 2811,
+    "total_elevation_gain": 28.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-07-15T11:59:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2323.8,
+    "moving_time": 1301,
+    "total_elevation_gain": 19.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-07-12T13:14:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3522.1,
+    "moving_time": 2741,
+    "total_elevation_gain": 19.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-01T10:19:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4262.8,
+    "moving_time": 3875,
+    "total_elevation_gain": 25.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-25T10:29:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12107.2,
+    "moving_time": 3646,
+    "total_elevation_gain": 27.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-12-09T18:26:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4129.6,
+    "moving_time": 3060,
+    "total_elevation_gain": 18.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-14T14:41:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2671.3,
+    "moving_time": 1786,
+    "total_elevation_gain": 22.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-03-23T18:50:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9883.9,
+    "moving_time": 3281,
+    "total_elevation_gain": 26.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-05-26T10:33:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4299.9,
+    "moving_time": 2881,
+    "total_elevation_gain": 38.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-09T16:22:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7643.7,
+    "moving_time": 4268,
+    "total_elevation_gain": 68.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-20T08:41:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4736.3,
+    "moving_time": 3922,
+    "total_elevation_gain": 39.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-01T13:16:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2356.9,
+    "moving_time": 1366,
+    "total_elevation_gain": 23.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-20T09:23:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5566.0,
+    "moving_time": 1452,
+    "total_elevation_gain": 23.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-29T16:39:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9166.1,
+    "moving_time": 2385,
+    "total_elevation_gain": 60.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-01-29T15:09:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3317.2,
+    "moving_time": 883,
+    "total_elevation_gain": 29.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-02-04T15:33:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9000.1,
+    "moving_time": 2263,
+    "total_elevation_gain": 61.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-03-28T14:48:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6533.4,
+    "moving_time": 1696,
+    "total_elevation_gain": 46.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-06-25T14:11:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4266.0,
+    "moving_time": 2601,
+    "total_elevation_gain": 27.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-06-20T19:40:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3925.8,
+    "moving_time": 3572,
+    "total_elevation_gain": 13.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-22T15:49:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1302.6,
+    "moving_time": 1133,
+    "total_elevation_gain": 6.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-08-23T11:32:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13346.7,
+    "moving_time": 3381,
+    "total_elevation_gain": 37.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-24T12:52:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9782.5,
+    "moving_time": 2571,
+    "total_elevation_gain": 85.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-24T14:20:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6974.2,
+    "moving_time": 5901,
+    "total_elevation_gain": 66.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-19T11:14:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12242.0,
+    "moving_time": 3400,
+    "total_elevation_gain": 76.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-29T08:09:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3884.1,
+    "moving_time": 1312,
+    "total_elevation_gain": 14.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-06-10T12:51:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2250.5,
+    "moving_time": 2462,
+    "total_elevation_gain": 21.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-09-19T12:52:15Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4625.3,
+    "moving_time": 3760,
+    "total_elevation_gain": 14.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-11-21T12:45:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2587.3,
+    "moving_time": 1771,
+    "total_elevation_gain": 17.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-04T10:20:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7038.2,
+    "moving_time": 4815,
+    "total_elevation_gain": 70.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-04-27T19:54:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7714.4,
+    "moving_time": 4627,
+    "total_elevation_gain": 38.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-28T09:55:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3376.2,
+    "moving_time": 1958,
+    "total_elevation_gain": 7.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-27T16:52:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3166.5,
+    "moving_time": 3461,
+    "total_elevation_gain": 29.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-20T15:04:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3870.2,
+    "moving_time": 980,
+    "total_elevation_gain": 27.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-02-02T07:56:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13532.4,
+    "moving_time": 3628,
+    "total_elevation_gain": 86.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-06-04T11:26:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2495.4,
+    "moving_time": 1544,
+    "total_elevation_gain": 18.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-01-29T15:19:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6481.7,
+    "moving_time": 2178,
+    "total_elevation_gain": 20.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-03-24T18:03:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3029.1,
+    "moving_time": 1037,
+    "total_elevation_gain": 12.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-03-10T16:34:36Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6980.1,
+    "moving_time": 5871,
+    "total_elevation_gain": 33.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-07-08T06:20:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3701.2,
+    "moving_time": 1050,
+    "total_elevation_gain": 34.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-02-16T17:46:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3180.6,
+    "moving_time": 2603,
+    "total_elevation_gain": 13.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-03-04T12:31:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7223.2,
+    "moving_time": 2169,
+    "total_elevation_gain": 46.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-08-20T14:25:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13049.0,
+    "moving_time": 3587,
+    "total_elevation_gain": 114.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-11-25T07:51:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10646.6,
+    "moving_time": 3497,
+    "total_elevation_gain": 45.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-18T09:26:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2478.5,
+    "moving_time": 1940,
+    "total_elevation_gain": 19.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-03-08T15:49:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7981.8,
+    "moving_time": 2274,
+    "total_elevation_gain": 21.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-12T11:43:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7717.1,
+    "moving_time": 5539,
+    "total_elevation_gain": 72.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-06-26T09:44:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6289.0,
+    "moving_time": 1741,
+    "total_elevation_gain": 55.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-10-12T12:42:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8966.6,
+    "moving_time": 2546,
+    "total_elevation_gain": 83.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-06-21T17:54:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7117.3,
+    "moving_time": 4573,
+    "total_elevation_gain": 55.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-07-20T17:14:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2130.0,
+    "moving_time": 1592,
+    "total_elevation_gain": 16.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-07-31T18:58:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6569.0,
+    "moving_time": 1920,
+    "total_elevation_gain": 48.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-23T15:53:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9817.1,
+    "moving_time": 2506,
+    "total_elevation_gain": 57.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-08-10T11:20:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14754.4,
+    "moving_time": 3934,
+    "total_elevation_gain": 75.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-07T08:44:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5160.5,
+    "moving_time": 5083,
+    "total_elevation_gain": 43.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-11T09:57:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7802.3,
+    "moving_time": 7255,
+    "total_elevation_gain": 37.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-03-24T16:01:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6339.4,
+    "moving_time": 1677,
+    "total_elevation_gain": 16.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-10-17T14:42:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4134.8,
+    "moving_time": 1412,
+    "total_elevation_gain": 38.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-03-19T19:03:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7727.4,
+    "moving_time": 7061,
+    "total_elevation_gain": 47.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-11-19T11:51:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14039.5,
+    "moving_time": 4929,
+    "total_elevation_gain": 111.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-29T19:59:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11757.6,
+    "moving_time": 3619,
+    "total_elevation_gain": 96.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-08-14T17:54:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2504.4,
+    "moving_time": 1918,
+    "total_elevation_gain": 22.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-07T14:01:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11093.8,
+    "moving_time": 3598,
+    "total_elevation_gain": 110.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-04-28T18:03:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13674.8,
+    "moving_time": 3657,
+    "total_elevation_gain": 64.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-12-26T09:50:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7961.9,
+    "moving_time": 8801,
+    "total_elevation_gain": 77.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-11-09T14:35:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6478.9,
+    "moving_time": 2516,
+    "total_elevation_gain": 19.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-12T14:37:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3533.5,
+    "moving_time": 1120,
+    "total_elevation_gain": 28.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-03T18:39:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11869.6,
+    "moving_time": 3585,
+    "total_elevation_gain": 83.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-08-15T19:24:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2889.3,
+    "moving_time": 2182,
+    "total_elevation_gain": 8.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-21T15:40:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7299.8,
+    "moving_time": 2876,
+    "total_elevation_gain": 20.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-05T11:27:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8334.1,
+    "moving_time": 2358,
+    "total_elevation_gain": 23.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-09-09T17:42:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11239.6,
+    "moving_time": 2867,
+    "total_elevation_gain": 101.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-08T14:01:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12272.4,
+    "moving_time": 4772,
+    "total_elevation_gain": 49.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-10-08T18:07:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7078.2,
+    "moving_time": 6654,
+    "total_elevation_gain": 29.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-24T08:20:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7296.4,
+    "moving_time": 7127,
+    "total_elevation_gain": 57.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-07-08T09:13:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5269.4,
+    "moving_time": 3130,
+    "total_elevation_gain": 12.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-08-16T12:59:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9892.6,
+    "moving_time": 2682,
+    "total_elevation_gain": 32.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-02-22T15:03:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4918.3,
+    "moving_time": 3313,
+    "total_elevation_gain": 11.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-04-21T16:00:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11322.7,
+    "moving_time": 2917,
+    "total_elevation_gain": 70.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-04T17:03:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4669.3,
+    "moving_time": 3972,
+    "total_elevation_gain": 36.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-28T10:43:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3732.3,
+    "moving_time": 2803,
+    "total_elevation_gain": 25.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-10T19:31:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11967.5,
+    "moving_time": 3640,
+    "total_elevation_gain": 79.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-02-22T16:00:54Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6529.8,
+    "moving_time": 5797,
+    "total_elevation_gain": 34.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-03-25T06:06:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3604.9,
+    "moving_time": 908,
+    "total_elevation_gain": 25.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-05-17T11:31:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3340.1,
+    "moving_time": 2066,
+    "total_elevation_gain": 21.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-10T16:06:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5220.7,
+    "moving_time": 3331,
+    "total_elevation_gain": 38.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-07-26T10:00:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3348.4,
+    "moving_time": 2859,
+    "total_elevation_gain": 13.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-12-31T15:49:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3308.4,
+    "moving_time": 968,
+    "total_elevation_gain": 19.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-07T14:48:06Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6674.1,
+    "moving_time": 4172,
+    "total_elevation_gain": 50.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-02T19:34:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4509.0,
+    "moving_time": 4389,
+    "total_elevation_gain": 16.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-08T10:38:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7957.7,
+    "moving_time": 6298,
+    "total_elevation_gain": 40.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-28T08:48:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3202.4,
+    "moving_time": 1270,
+    "total_elevation_gain": 20.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-01-12T11:37:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4908.3,
+    "moving_time": 1490,
+    "total_elevation_gain": 45.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-17T19:49:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6271.4,
+    "moving_time": 3994,
+    "total_elevation_gain": 33.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-18T19:16:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4596.4,
+    "moving_time": 2830,
+    "total_elevation_gain": 37.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-30T08:47:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4980.8,
+    "moving_time": 3274,
+    "total_elevation_gain": 26.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-17T10:56:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12342.8,
+    "moving_time": 3759,
+    "total_elevation_gain": 72.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-09-16T14:37:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10726.6,
+    "moving_time": 3855,
+    "total_elevation_gain": 47.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-02-06T11:43:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2924.8,
+    "moving_time": 784,
+    "total_elevation_gain": 16.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-10-20T16:28:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3217.6,
+    "moving_time": 2438,
+    "total_elevation_gain": 7.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-12T17:21:54Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7430.9,
+    "moving_time": 2142,
+    "total_elevation_gain": 50.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-27T15:46:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3286.8,
+    "moving_time": 977,
+    "total_elevation_gain": 23.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-11-05T14:53:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10603.0,
+    "moving_time": 3793,
+    "total_elevation_gain": 30.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-10-10T15:52:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5023.4,
+    "moving_time": 3475,
+    "total_elevation_gain": 27.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-01T08:02:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6443.4,
+    "moving_time": 5167,
+    "total_elevation_gain": 56.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-01-14T14:33:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11598.3,
+    "moving_time": 2950,
+    "total_elevation_gain": 99.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-09-26T10:36:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5955.1,
+    "moving_time": 4682,
+    "total_elevation_gain": 48.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-11-25T15:52:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1135.3,
+    "moving_time": 888,
+    "total_elevation_gain": 5.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-10T08:05:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9670.6,
+    "moving_time": 3520,
+    "total_elevation_gain": 58.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-02T11:04:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5999.2,
+    "moving_time": 2027,
+    "total_elevation_gain": 20.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-07-24T06:40:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4137.1,
+    "moving_time": 2998,
+    "total_elevation_gain": 28.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-05-06T10:44:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4907.9,
+    "moving_time": 3352,
+    "total_elevation_gain": 17.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-07-25T09:47:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9203.3,
+    "moving_time": 2327,
+    "total_elevation_gain": 37.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-07-02T12:46:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4731.4,
+    "moving_time": 5067,
+    "total_elevation_gain": 32.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-03-02T11:32:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1830.6,
+    "moving_time": 1207,
+    "total_elevation_gain": 8.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-07-18T18:57:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2204.0,
+    "moving_time": 1791,
+    "total_elevation_gain": 5.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-17T17:22:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6151.5,
+    "moving_time": 2084,
+    "total_elevation_gain": 25.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-10-20T15:00:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5544.0,
+    "moving_time": 5187,
+    "total_elevation_gain": 19.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-25T10:28:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7109.0,
+    "moving_time": 4390,
+    "total_elevation_gain": 65.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-16T09:12:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5473.9,
+    "moving_time": 1705,
+    "total_elevation_gain": 16.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-01-11T17:56:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13158.9,
+    "moving_time": 3431,
+    "total_elevation_gain": 27.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-05-25T10:11:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7841.3,
+    "moving_time": 8092,
+    "total_elevation_gain": 44.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-21T11:50:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2396.2,
+    "moving_time": 1651,
+    "total_elevation_gain": 8.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-16T12:38:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4382.5,
+    "moving_time": 2681,
+    "total_elevation_gain": 15.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-13T19:45:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7773.3,
+    "moving_time": 4594,
+    "total_elevation_gain": 28.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-02-27T06:33:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2639.4,
+    "moving_time": 809,
+    "total_elevation_gain": 10.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-05-11T06:47:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11454.3,
+    "moving_time": 3202,
+    "total_elevation_gain": 58.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-14T11:01:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2754.1,
+    "moving_time": 2785,
+    "total_elevation_gain": 15.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-03-16T12:11:36Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7183.8,
+    "moving_time": 4851,
+    "total_elevation_gain": 53.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-08-29T09:19:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4841.2,
+    "moving_time": 3632,
+    "total_elevation_gain": 43.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-17T18:10:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5755.9,
+    "moving_time": 2030,
+    "total_elevation_gain": 47.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-10-05T12:34:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10017.2,
+    "moving_time": 3069,
+    "total_elevation_gain": 20.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-12-16T16:52:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7289.9,
+    "moving_time": 7512,
+    "total_elevation_gain": 15.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-14T18:46:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12603.5,
+    "moving_time": 3974,
+    "total_elevation_gain": 49.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-11-23T12:23:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1351.2,
+    "moving_time": 1060,
+    "total_elevation_gain": 6.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-13T13:00:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7727.9,
+    "moving_time": 5693,
+    "total_elevation_gain": 38.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-02-20T18:53:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7434.2,
+    "moving_time": 6439,
+    "total_elevation_gain": 30.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-17T06:20:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4818.1,
+    "moving_time": 1419,
+    "total_elevation_gain": 32.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-03T07:44:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1554.3,
+    "moving_time": 970,
+    "total_elevation_gain": 12.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-11-16T13:06:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13136.3,
+    "moving_time": 3916,
+    "total_elevation_gain": 59.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-23T13:11:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2712.3,
+    "moving_time": 699,
+    "total_elevation_gain": 17.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-09-10T07:13:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6089.0,
+    "moving_time": 3412,
+    "total_elevation_gain": 49.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-22T17:23:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2397.5,
+    "moving_time": 725,
+    "total_elevation_gain": 20.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-10-09T13:39:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12542.2,
+    "moving_time": 4950,
+    "total_elevation_gain": 109.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-02-23T18:23:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11296.2,
+    "moving_time": 3010,
+    "total_elevation_gain": 84.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-11T08:53:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14609.7,
+    "moving_time": 4817,
+    "total_elevation_gain": 45.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-12-12T12:41:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7417.3,
+    "moving_time": 4465,
+    "total_elevation_gain": 47.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-13T17:30:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2090.5,
+    "moving_time": 1403,
+    "total_elevation_gain": 14.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-10-11T18:06:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8747.5,
+    "moving_time": 2445,
+    "total_elevation_gain": 55.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-06-01T14:13:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12941.7,
+    "moving_time": 3294,
+    "total_elevation_gain": 79.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-17T17:07:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13077.7,
+    "moving_time": 3730,
+    "total_elevation_gain": 129.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-22T07:38:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5856.4,
+    "moving_time": 3584,
+    "total_elevation_gain": 38.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-07-22T19:47:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4700.6,
+    "moving_time": 1193,
+    "total_elevation_gain": 12.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-09-05T19:59:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5565.7,
+    "moving_time": 1899,
+    "total_elevation_gain": 19.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-27T15:37:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3870.5,
+    "moving_time": 4016,
+    "total_elevation_gain": 17.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-24T11:09:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5232.6,
+    "moving_time": 4650,
+    "total_elevation_gain": 32.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-31T12:25:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3714.0,
+    "moving_time": 1124,
+    "total_elevation_gain": 24.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-14T15:40:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9642.9,
+    "moving_time": 2800,
+    "total_elevation_gain": 32.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-11-26T07:45:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4809.7,
+    "moving_time": 3071,
+    "total_elevation_gain": 46.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-15T12:46:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3799.0,
+    "moving_time": 1072,
+    "total_elevation_gain": 26.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-04-16T18:14:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5294.0,
+    "moving_time": 4617,
+    "total_elevation_gain": 30.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-18T15:02:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11040.3,
+    "moving_time": 3932,
+    "total_elevation_gain": 46.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-03-24T19:15:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3928.3,
+    "moving_time": 3979,
+    "total_elevation_gain": 12.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-08-20T09:20:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12503.7,
+    "moving_time": 4305,
+    "total_elevation_gain": 69.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-06-22T19:19:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7162.4,
+    "moving_time": 2292,
+    "total_elevation_gain": 53.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-06T15:48:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13180.1,
+    "moving_time": 4763,
+    "total_elevation_gain": 48.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-19T19:35:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10809.2,
+    "moving_time": 2813,
+    "total_elevation_gain": 103.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-08-30T13:24:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3758.1,
+    "moving_time": 1077,
+    "total_elevation_gain": 25.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-05T09:35:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7479.8,
+    "moving_time": 5748,
+    "total_elevation_gain": 54.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-11-05T15:57:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5021.1,
+    "moving_time": 3503,
+    "total_elevation_gain": 24.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-17T18:23:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6580.3,
+    "moving_time": 3732,
+    "total_elevation_gain": 13.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-12-27T08:57:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4654.2,
+    "moving_time": 4030,
+    "total_elevation_gain": 30.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-11-02T10:02:54Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2638.6,
+    "moving_time": 1039,
+    "total_elevation_gain": 14.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-26T17:11:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4163.4,
+    "moving_time": 4373,
+    "total_elevation_gain": 10.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-11-10T06:53:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7078.1,
+    "moving_time": 2164,
+    "total_elevation_gain": 43.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-05-23T06:25:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1804.2,
+    "moving_time": 1254,
+    "total_elevation_gain": 11.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-28T15:09:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6162.2,
+    "moving_time": 3981,
+    "total_elevation_gain": 31.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-29T16:30:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8580.3,
+    "moving_time": 2222,
+    "total_elevation_gain": 54.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-10T06:59:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3584.7,
+    "moving_time": 2953,
+    "total_elevation_gain": 24.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-09T10:59:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10867.0,
+    "moving_time": 3451,
+    "total_elevation_gain": 53.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-10-12T13:19:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7266.4,
+    "moving_time": 5675,
+    "total_elevation_gain": 42.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-09-29T19:05:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5730.7,
+    "moving_time": 6235,
+    "total_elevation_gain": 24.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-02T07:08:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6573.6,
+    "moving_time": 4489,
+    "total_elevation_gain": 61.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-10-15T11:05:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9289.3,
+    "moving_time": 2634,
+    "total_elevation_gain": 85.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-01-21T14:07:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5269.1,
+    "moving_time": 1417,
+    "total_elevation_gain": 37.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-10-01T11:17:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1353.4,
+    "moving_time": 1483,
+    "total_elevation_gain": 4.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-03-11T14:59:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5307.6,
+    "moving_time": 5587,
+    "total_elevation_gain": 20.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-25T18:12:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2170.2,
+    "moving_time": 1363,
+    "total_elevation_gain": 5.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-28T13:33:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5101.6,
+    "moving_time": 5444,
+    "total_elevation_gain": 25.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-08-21T10:28:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1222.5,
+    "moving_time": 1174,
+    "total_elevation_gain": 12.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-24T10:46:54Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14517.3,
+    "moving_time": 4093,
+    "total_elevation_gain": 47.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-09T13:58:36Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2052.2,
+    "moving_time": 1424,
+    "total_elevation_gain": 13.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-11-16T19:48:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3818.2,
+    "moving_time": 2368,
+    "total_elevation_gain": 33.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-28T19:35:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2255.1,
+    "moving_time": 1801,
+    "total_elevation_gain": 11.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-06-20T19:08:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11791.7,
+    "moving_time": 3387,
+    "total_elevation_gain": 65.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-10-19T19:12:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3892.9,
+    "moving_time": 3902,
+    "total_elevation_gain": 31.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-10-14T13:45:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2028.6,
+    "moving_time": 597,
+    "total_elevation_gain": 6.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-23T07:08:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4061.7,
+    "moving_time": 2453,
+    "total_elevation_gain": 38.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-02T10:26:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7942.1,
+    "moving_time": 4686,
+    "total_elevation_gain": 16.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-17T08:24:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3553.8,
+    "moving_time": 3784,
+    "total_elevation_gain": 7.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-06-23T17:57:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12277.1,
+    "moving_time": 4846,
+    "total_elevation_gain": 104.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-11T12:45:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1803.2,
+    "moving_time": 1008,
+    "total_elevation_gain": 16.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-06-29T18:33:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13965.9,
+    "moving_time": 5466,
+    "total_elevation_gain": 118.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-06-12T12:31:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13571.0,
+    "moving_time": 5018,
+    "total_elevation_gain": 52.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-07-01T07:16:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9916.6,
+    "moving_time": 3420,
+    "total_elevation_gain": 56.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-06T08:46:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12691.0,
+    "moving_time": 4142,
+    "total_elevation_gain": 71.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-06-30T14:50:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7995.4,
+    "moving_time": 2250,
+    "total_elevation_gain": 52.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-08T06:50:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3052.0,
+    "moving_time": 1945,
+    "total_elevation_gain": 17.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-13T18:15:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2021.1,
+    "moving_time": 563,
+    "total_elevation_gain": 11.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-10-16T10:49:54Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6763.1,
+    "moving_time": 2000,
+    "total_elevation_gain": 54.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-12T13:39:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11080.4,
+    "moving_time": 3009,
+    "total_elevation_gain": 103.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-13T12:23:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3143.1,
+    "moving_time": 2976,
+    "total_elevation_gain": 21.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-07-22T14:50:16Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9253.6,
+    "moving_time": 3594,
+    "total_elevation_gain": 79.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-11-29T10:01:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5013.9,
+    "moving_time": 1259,
+    "total_elevation_gain": 21.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-21T06:29:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3615.1,
+    "moving_time": 2068,
+    "total_elevation_gain": 11.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-02T06:44:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3222.3,
+    "moving_time": 2908,
+    "total_elevation_gain": 23.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-10-21T11:37:06Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7318.1,
+    "moving_time": 5173,
+    "total_elevation_gain": 22.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-03T10:43:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4983.0,
+    "moving_time": 1651,
+    "total_elevation_gain": 47.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-08-12T14:37:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11619.6,
+    "moving_time": 2982,
+    "total_elevation_gain": 80.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-07T11:47:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7843.3,
+    "moving_time": 2852,
+    "total_elevation_gain": 22.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-06-19T16:08:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2551.2,
+    "moving_time": 986,
+    "total_elevation_gain": 13.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-05-16T19:01:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9438.1,
+    "moving_time": 2970,
+    "total_elevation_gain": 64.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-19T09:16:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4661.5,
+    "moving_time": 3525,
+    "total_elevation_gain": 38.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-29T06:47:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5816.8,
+    "moving_time": 6335,
+    "total_elevation_gain": 17.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-03-30T14:53:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7252.1,
+    "moving_time": 1926,
+    "total_elevation_gain": 24.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-04-08T07:47:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2402.1,
+    "moving_time": 831,
+    "total_elevation_gain": 14.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-19T19:46:16Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4889.2,
+    "moving_time": 3666,
+    "total_elevation_gain": 27.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-03-12T15:40:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4339.9,
+    "moving_time": 1245,
+    "total_elevation_gain": 12.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-30T16:38:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6816.4,
+    "moving_time": 4086,
+    "total_elevation_gain": 63.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-11-17T14:15:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4280.7,
+    "moving_time": 1336,
+    "total_elevation_gain": 21.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-12T10:16:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6802.0,
+    "moving_time": 4134,
+    "total_elevation_gain": 55.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-02T16:12:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7028.4,
+    "moving_time": 1955,
+    "total_elevation_gain": 25.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-12T11:09:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4754.7,
+    "moving_time": 3460,
+    "total_elevation_gain": 38.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-28T13:26:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2298.8,
+    "moving_time": 830,
+    "total_elevation_gain": 6.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-07T11:04:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13485.7,
+    "moving_time": 4640,
+    "total_elevation_gain": 123.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-20T06:47:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7861.2,
+    "moving_time": 4902,
+    "total_elevation_gain": 44.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-14T09:09:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2331.8,
+    "moving_time": 1381,
+    "total_elevation_gain": 22.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-13T16:51:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7253.7,
+    "moving_time": 8012,
+    "total_elevation_gain": 63.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-12T06:57:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12732.4,
+    "moving_time": 4889,
+    "total_elevation_gain": 35.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-21T06:04:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4377.7,
+    "moving_time": 3746,
+    "total_elevation_gain": 31.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-04-01T17:34:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8747.4,
+    "moving_time": 3123,
+    "total_elevation_gain": 79.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-03-08T17:10:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6225.4,
+    "moving_time": 3774,
+    "total_elevation_gain": 13.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-11-13T18:00:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9329.5,
+    "moving_time": 2934,
+    "total_elevation_gain": 77.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-04-26T19:02:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6901.6,
+    "moving_time": 2249,
+    "total_elevation_gain": 30.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-16T09:50:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2201.3,
+    "moving_time": 1987,
+    "total_elevation_gain": 11.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-08-30T06:26:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6159.3,
+    "moving_time": 6668,
+    "total_elevation_gain": 41.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-09-09T14:10:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12110.9,
+    "moving_time": 4063,
+    "total_elevation_gain": 62.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-11T09:57:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3389.5,
+    "moving_time": 2094,
+    "total_elevation_gain": 24.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-11-03T16:43:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1952.0,
+    "moving_time": 1782,
+    "total_elevation_gain": 10.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-09-19T17:00:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7147.6,
+    "moving_time": 2452,
+    "total_elevation_gain": 67.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-12-09T15:37:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7111.0,
+    "moving_time": 7406,
+    "total_elevation_gain": 21.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-07-14T13:30:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11212.4,
+    "moving_time": 3866,
+    "total_elevation_gain": 23.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-02T17:58:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5510.8,
+    "moving_time": 3853,
+    "total_elevation_gain": 17.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-09-19T08:19:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5531.9,
+    "moving_time": 1458,
+    "total_elevation_gain": 47.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-06-05T15:02:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6836.1,
+    "moving_time": 1895,
+    "total_elevation_gain": 36.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-02T14:45:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3308.0,
+    "moving_time": 3282,
+    "total_elevation_gain": 32.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-30T14:33:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6496.6,
+    "moving_time": 2230,
+    "total_elevation_gain": 62.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-09-19T12:19:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1634.8,
+    "moving_time": 1375,
+    "total_elevation_gain": 7.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-06-13T07:45:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1558.0,
+    "moving_time": 1203,
+    "total_elevation_gain": 12.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-08-25T14:34:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2824.8,
+    "moving_time": 887,
+    "total_elevation_gain": 25.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-14T12:16:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2358.4,
+    "moving_time": 859,
+    "total_elevation_gain": 18.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-05-15T14:16:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4148.9,
+    "moving_time": 1068,
+    "total_elevation_gain": 40.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-09T15:31:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1562.5,
+    "moving_time": 1034,
+    "total_elevation_gain": 7.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-01T09:56:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12595.0,
+    "moving_time": 4909,
+    "total_elevation_gain": 66.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-20T07:52:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7695.9,
+    "moving_time": 4414,
+    "total_elevation_gain": 18.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-24T07:36:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10460.8,
+    "moving_time": 3705,
+    "total_elevation_gain": 51.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-07-11T14:11:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9120.0,
+    "moving_time": 3442,
+    "total_elevation_gain": 42.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-03-02T18:04:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3930.9,
+    "moving_time": 4328,
+    "total_elevation_gain": 16.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-08-22T18:03:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3267.6,
+    "moving_time": 2498,
+    "total_elevation_gain": 9.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-30T15:05:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14171.8,
+    "moving_time": 5233,
+    "total_elevation_gain": 89.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-17T15:20:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3774.0,
+    "moving_time": 2670,
+    "total_elevation_gain": 20.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-05T10:53:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11776.9,
+    "moving_time": 3847,
+    "total_elevation_gain": 83.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-03-18T13:39:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3000.0,
+    "moving_time": 1683,
+    "total_elevation_gain": 15.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-01-28T14:53:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2990.3,
+    "moving_time": 844,
+    "total_elevation_gain": 15.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-10T09:20:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10140.9,
+    "moving_time": 3387,
+    "total_elevation_gain": 70.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-03T10:25:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5215.9,
+    "moving_time": 3977,
+    "total_elevation_gain": 35.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-03-02T17:36:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2227.4,
+    "moving_time": 572,
+    "total_elevation_gain": 19.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-27T16:24:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4983.4,
+    "moving_time": 1379,
+    "total_elevation_gain": 36.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-05-02T18:41:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12282.0,
+    "moving_time": 3270,
+    "total_elevation_gain": 60.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-13T17:36:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12447.0,
+    "moving_time": 4023,
+    "total_elevation_gain": 50.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-06-01T17:55:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13859.4,
+    "moving_time": 3881,
+    "total_elevation_gain": 85.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-26T11:49:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7025.1,
+    "moving_time": 4622,
+    "total_elevation_gain": 40.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-06-22T12:09:05Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2656.9,
+    "moving_time": 1562,
+    "total_elevation_gain": 13.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-04T12:57:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2455.1,
+    "moving_time": 2112,
+    "total_elevation_gain": 5.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-09-25T08:14:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8107.5,
+    "moving_time": 2116,
+    "total_elevation_gain": 30.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-05-11T11:33:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6116.3,
+    "moving_time": 5671,
+    "total_elevation_gain": 43.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-01-22T15:29:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11414.7,
+    "moving_time": 4400,
+    "total_elevation_gain": 30.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-03-01T09:27:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7812.5,
+    "moving_time": 5150,
+    "total_elevation_gain": 30.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-01T06:42:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12892.2,
+    "moving_time": 3460,
+    "total_elevation_gain": 106.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-03-16T15:54:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2106.1,
+    "moving_time": 557,
+    "total_elevation_gain": 17.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-05-10T08:19:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12072.0,
+    "moving_time": 4780,
+    "total_elevation_gain": 55.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-05-01T18:31:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5478.5,
+    "moving_time": 4001,
+    "total_elevation_gain": 26.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-16T12:51:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2905.1,
+    "moving_time": 3165,
+    "total_elevation_gain": 10.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-15T12:53:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2893.4,
+    "moving_time": 891,
+    "total_elevation_gain": 27.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-02-18T09:26:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3510.9,
+    "moving_time": 1043,
+    "total_elevation_gain": 19.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-03-29T12:34:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5596.9,
+    "moving_time": 3908,
+    "total_elevation_gain": 29.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-03-25T18:06:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12863.0,
+    "moving_time": 3639,
+    "total_elevation_gain": 77.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-04-10T17:32:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12067.0,
+    "moving_time": 4328,
+    "total_elevation_gain": 88.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-25T12:30:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5676.4,
+    "moving_time": 1522,
+    "total_elevation_gain": 39.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-06-21T16:26:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12849.1,
+    "moving_time": 4350,
+    "total_elevation_gain": 43.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-08-25T13:46:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9065.1,
+    "moving_time": 2753,
+    "total_elevation_gain": 23.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-20T12:19:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2638.6,
+    "moving_time": 670,
+    "total_elevation_gain": 6.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-03-21T06:00:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6835.7,
+    "moving_time": 5066,
+    "total_elevation_gain": 23.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-04T10:53:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4035.8,
+    "moving_time": 3288,
+    "total_elevation_gain": 34.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-02-14T18:39:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7512.8,
+    "moving_time": 7110,
+    "total_elevation_gain": 60.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-08-02T09:04:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3416.3,
+    "moving_time": 2281,
+    "total_elevation_gain": 6.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-20T15:47:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7104.0,
+    "moving_time": 2568,
+    "total_elevation_gain": 67.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-22T18:58:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5572.8,
+    "moving_time": 3214,
+    "total_elevation_gain": 41.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-17T10:24:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2263.2,
+    "moving_time": 1876,
+    "total_elevation_gain": 7.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-28T06:53:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4895.5,
+    "moving_time": 1847,
+    "total_elevation_gain": 16.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-08T10:01:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14224.6,
+    "moving_time": 4273,
+    "total_elevation_gain": 141.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-09-27T19:51:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6988.9,
+    "moving_time": 1877,
+    "total_elevation_gain": 67.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-10-19T15:52:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4957.8,
+    "moving_time": 1264,
+    "total_elevation_gain": 14.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-06-25T16:11:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4644.0,
+    "moving_time": 3112,
+    "total_elevation_gain": 46.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-11-14T09:39:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4240.0,
+    "moving_time": 3513,
+    "total_elevation_gain": 35.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-08-14T15:42:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7298.9,
+    "moving_time": 7294,
+    "total_elevation_gain": 57.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-02-05T12:26:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12866.5,
+    "moving_time": 4208,
+    "total_elevation_gain": 73.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-05-31T15:51:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3552.1,
+    "moving_time": 1282,
+    "total_elevation_gain": 29.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-01-29T13:24:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10650.8,
+    "moving_time": 3627,
+    "total_elevation_gain": 93.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-11T06:54:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1075.1,
+    "moving_time": 622,
+    "total_elevation_gain": 9.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-09-10T14:56:15Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5936.8,
+    "moving_time": 3990,
+    "total_elevation_gain": 46.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-01-12T13:15:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2641.6,
+    "moving_time": 2478,
+    "total_elevation_gain": 21.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-09-15T09:05:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6284.6,
+    "moving_time": 4040,
+    "total_elevation_gain": 38.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-05-13T07:00:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6025.4,
+    "moving_time": 3862,
+    "total_elevation_gain": 46.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-11-26T17:28:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4014.6,
+    "moving_time": 2452,
+    "total_elevation_gain": 13.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-22T14:27:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11855.5,
+    "moving_time": 3714,
+    "total_elevation_gain": 97.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-16T07:24:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6749.6,
+    "moving_time": 2609,
+    "total_elevation_gain": 56.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-07T18:23:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4870.5,
+    "moving_time": 3785,
+    "total_elevation_gain": 31.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-01-25T07:04:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2198.9,
+    "moving_time": 634,
+    "total_elevation_gain": 6.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-06-18T07:10:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5671.2,
+    "moving_time": 6274,
+    "total_elevation_gain": 15.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-29T06:45:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4963.9,
+    "moving_time": 1856,
+    "total_elevation_gain": 31.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-07-01T13:58:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10800.7,
+    "moving_time": 3732,
+    "total_elevation_gain": 89.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-19T06:08:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3502.6,
+    "moving_time": 1126,
+    "total_elevation_gain": 23.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-26T17:54:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4298.4,
+    "moving_time": 2579,
+    "total_elevation_gain": 20.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-02-20T09:42:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4639.6,
+    "moving_time": 2623,
+    "total_elevation_gain": 39.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-03-30T07:14:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2541.7,
+    "moving_time": 1879,
+    "total_elevation_gain": 24.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-09T15:06:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7125.1,
+    "moving_time": 2412,
+    "total_elevation_gain": 25.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-15T16:29:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3567.5,
+    "moving_time": 2193,
+    "total_elevation_gain": 25.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-11-02T12:09:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14392.6,
+    "moving_time": 4499,
+    "total_elevation_gain": 133.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-01-28T08:44:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3983.2,
+    "moving_time": 3171,
+    "total_elevation_gain": 22.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-05T14:30:16Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7247.2,
+    "moving_time": 6096,
+    "total_elevation_gain": 55.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-04-24T18:55:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2964.3,
+    "moving_time": 2005,
+    "total_elevation_gain": 19.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-09-05T15:44:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5417.3,
+    "moving_time": 5523,
+    "total_elevation_gain": 41.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-11-09T11:32:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7861.8,
+    "moving_time": 6642,
+    "total_elevation_gain": 39.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-23T14:37:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2222.1,
+    "moving_time": 2085,
+    "total_elevation_gain": 13.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-23T14:21:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13773.2,
+    "moving_time": 4508,
+    "total_elevation_gain": 89.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-07T06:49:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1091.9,
+    "moving_time": 1129,
+    "total_elevation_gain": 10.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-27T18:46:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4401.7,
+    "moving_time": 4581,
+    "total_elevation_gain": 10.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-15T15:54:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7163.4,
+    "moving_time": 6460,
+    "total_elevation_gain": 49.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-22T10:44:06Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7267.3,
+    "moving_time": 4648,
+    "total_elevation_gain": 67.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-28T06:01:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8402.9,
+    "moving_time": 2551,
+    "total_elevation_gain": 73.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-03-27T06:33:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5308.2,
+    "moving_time": 3613,
+    "total_elevation_gain": 18.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-09-29T14:05:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5248.4,
+    "moving_time": 5227,
+    "total_elevation_gain": 46.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-04T06:16:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5734.9,
+    "moving_time": 3663,
+    "total_elevation_gain": 27.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-02T06:30:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7301.9,
+    "moving_time": 2220,
+    "total_elevation_gain": 65.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-26T09:44:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8718.9,
+    "moving_time": 2260,
+    "total_elevation_gain": 23.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-19T17:18:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3520.4,
+    "moving_time": 3166,
+    "total_elevation_gain": 12.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-07-25T14:19:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14141.2,
+    "moving_time": 4546,
+    "total_elevation_gain": 135.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-16T19:20:06Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5728.2,
+    "moving_time": 5399,
+    "total_elevation_gain": 52.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-09-25T19:38:36Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3389.6,
+    "moving_time": 1942,
+    "total_elevation_gain": 19.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-08-29T15:11:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6182.3,
+    "moving_time": 6743,
+    "total_elevation_gain": 47.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-06T07:01:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4704.9,
+    "moving_time": 1336,
+    "total_elevation_gain": 14.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-13T09:30:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1812.9,
+    "moving_time": 1076,
+    "total_elevation_gain": 12.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-03-08T16:28:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6222.6,
+    "moving_time": 2387,
+    "total_elevation_gain": 32.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-09T11:44:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7253.0,
+    "moving_time": 2070,
+    "total_elevation_gain": 62.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-12T14:57:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4783.4,
+    "moving_time": 1672,
+    "total_elevation_gain": 44.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-08-26T08:47:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9190.1,
+    "moving_time": 3223,
+    "total_elevation_gain": 38.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-09-29T14:00:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3798.6,
+    "moving_time": 1204,
+    "total_elevation_gain": 12.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-25T06:51:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11162.1,
+    "moving_time": 2928,
+    "total_elevation_gain": 88.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-10T11:15:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2437.8,
+    "moving_time": 1634,
+    "total_elevation_gain": 12.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-09-17T15:39:16Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8423.1,
+    "moving_time": 2803,
+    "total_elevation_gain": 36.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-12-08T07:42:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7598.1,
+    "moving_time": 4796,
+    "total_elevation_gain": 22.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-07-25T14:38:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13709.6,
+    "moving_time": 3794,
+    "total_elevation_gain": 80.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-22T11:34:36Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3470.2,
+    "moving_time": 1034,
+    "total_elevation_gain": 25.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-02-25T09:37:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11866.0,
+    "moving_time": 3011,
+    "total_elevation_gain": 53.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-02-15T07:03:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11814.5,
+    "moving_time": 2985,
+    "total_elevation_gain": 87.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-07-02T07:02:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5766.4,
+    "moving_time": 1579,
+    "total_elevation_gain": 34.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-03-13T07:33:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1303.9,
+    "moving_time": 731,
+    "total_elevation_gain": 9.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-11-24T16:51:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14800.8,
+    "moving_time": 4414,
+    "total_elevation_gain": 63.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-31T11:25:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12474.9,
+    "moving_time": 4391,
+    "total_elevation_gain": 93.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-05T06:44:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7236.0,
+    "moving_time": 6939,
+    "total_elevation_gain": 42.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-12-17T10:03:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4191.6,
+    "moving_time": 1067,
+    "total_elevation_gain": 25.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-08-27T08:43:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3640.1,
+    "moving_time": 920,
+    "total_elevation_gain": 30.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-02-28T16:49:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6638.0,
+    "moving_time": 7163,
+    "total_elevation_gain": 32.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-10-07T07:51:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2806.5,
+    "moving_time": 2700,
+    "total_elevation_gain": 14.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-09-01T17:36:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5598.2,
+    "moving_time": 3885,
+    "total_elevation_gain": 20.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-25T08:49:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1502.1,
+    "moving_time": 934,
+    "total_elevation_gain": 4.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-19T13:50:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6842.8,
+    "moving_time": 1966,
+    "total_elevation_gain": 28.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-05-20T18:56:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10457.1,
+    "moving_time": 3532,
+    "total_elevation_gain": 68.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-09-26T19:23:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6229.4,
+    "moving_time": 1807,
+    "total_elevation_gain": 23.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-08-09T07:47:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14370.3,
+    "moving_time": 4196,
+    "total_elevation_gain": 53.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-03-28T16:40:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6996.7,
+    "moving_time": 2292,
+    "total_elevation_gain": 43.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-09-16T16:59:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13691.2,
+    "moving_time": 4681,
+    "total_elevation_gain": 67.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-07T09:01:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7285.0,
+    "moving_time": 1899,
+    "total_elevation_gain": 28.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-12-25T07:11:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5236.0,
+    "moving_time": 5242,
+    "total_elevation_gain": 50.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-04-04T12:13:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5782.9,
+    "moving_time": 2017,
+    "total_elevation_gain": 47.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-12-08T07:59:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6844.7,
+    "moving_time": 5617,
+    "total_elevation_gain": 15.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-09-27T11:25:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4278.9,
+    "moving_time": 2864,
+    "total_elevation_gain": 21.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-07T08:11:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10529.1,
+    "moving_time": 4059,
+    "total_elevation_gain": 99.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-11T11:12:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6064.5,
+    "moving_time": 4471,
+    "total_elevation_gain": 35.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-07-21T06:10:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5357.7,
+    "moving_time": 3140,
+    "total_elevation_gain": 52.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-07-06T10:30:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7513.1,
+    "moving_time": 6820,
+    "total_elevation_gain": 46.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-13T11:21:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10031.6,
+    "moving_time": 3048,
+    "total_elevation_gain": 93.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-02-16T09:51:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11648.2,
+    "moving_time": 4017,
+    "total_elevation_gain": 59.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-14T11:26:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2835.9,
+    "moving_time": 1980,
+    "total_elevation_gain": 18.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-16T06:56:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7403.8,
+    "moving_time": 2503,
+    "total_elevation_gain": 69.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-09-12T17:02:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7430.7,
+    "moving_time": 4736,
+    "total_elevation_gain": 24.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-05-30T07:51:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2629.0,
+    "moving_time": 871,
+    "total_elevation_gain": 22.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-11T13:33:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1885.1,
+    "moving_time": 1986,
+    "total_elevation_gain": 17.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-12-01T14:09:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6566.8,
+    "moving_time": 4368,
+    "total_elevation_gain": 37.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-03-05T14:17:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4367.5,
+    "moving_time": 3392,
+    "total_elevation_gain": 10.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-10-06T13:33:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5103.3,
+    "moving_time": 5597,
+    "total_elevation_gain": 18.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-24T13:39:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5286.1,
+    "moving_time": 4504,
+    "total_elevation_gain": 37.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-15T16:02:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4029.5,
+    "moving_time": 3744,
+    "total_elevation_gain": 9.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-11-19T13:45:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2578.2,
+    "moving_time": 1691,
+    "total_elevation_gain": 13.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-22T15:27:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7895.9,
+    "moving_time": 2067,
+    "total_elevation_gain": 68.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-09-03T15:43:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9294.4,
+    "moving_time": 2603,
+    "total_elevation_gain": 67.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-08T12:44:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2501.7,
+    "moving_time": 2431,
+    "total_elevation_gain": 23.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-13T14:50:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4212.3,
+    "moving_time": 1682,
+    "total_elevation_gain": 24.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-11-23T15:27:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1940.5,
+    "moving_time": 1818,
+    "total_elevation_gain": 17.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-08-12T08:33:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6670.9,
+    "moving_time": 4483,
+    "total_elevation_gain": 60.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-10-26T14:39:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6064.5,
+    "moving_time": 6639,
+    "total_elevation_gain": 36.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-03-06T10:03:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7940.0,
+    "moving_time": 5415,
+    "total_elevation_gain": 38.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-09T18:57:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13935.1,
+    "moving_time": 3645,
+    "total_elevation_gain": 102.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-12-23T07:24:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9042.3,
+    "moving_time": 2624,
+    "total_elevation_gain": 60.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-11-03T18:46:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5798.3,
+    "moving_time": 1535,
+    "total_elevation_gain": 26.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-04-08T15:51:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11505.2,
+    "moving_time": 3407,
+    "total_elevation_gain": 81.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-06-22T19:29:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3888.7,
+    "moving_time": 1079,
+    "total_elevation_gain": 21.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-09-21T09:18:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3919.8,
+    "moving_time": 3273,
+    "total_elevation_gain": 9.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-03-19T13:59:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6016.9,
+    "moving_time": 3354,
+    "total_elevation_gain": 57.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-06T18:34:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5134.0,
+    "moving_time": 1325,
+    "total_elevation_gain": 10.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-01-12T19:15:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1642.0,
+    "moving_time": 964,
+    "total_elevation_gain": 9.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-03-09T16:14:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4457.2,
+    "moving_time": 4040,
+    "total_elevation_gain": 33.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-17T08:52:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5844.2,
+    "moving_time": 4689,
+    "total_elevation_gain": 53.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-10-05T13:45:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2572.4,
+    "moving_time": 743,
+    "total_elevation_gain": 10.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-19T11:54:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6974.2,
+    "moving_time": 7021,
+    "total_elevation_gain": 57.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-29T11:53:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7333.2,
+    "moving_time": 7109,
+    "total_elevation_gain": 46.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-02-15T17:02:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7748.0,
+    "moving_time": 2104,
+    "total_elevation_gain": 72.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-16T10:16:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2652.4,
+    "moving_time": 2157,
+    "total_elevation_gain": 8.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-08T13:07:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6417.5,
+    "moving_time": 4706,
+    "total_elevation_gain": 64.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-09-18T13:02:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2183.2,
+    "moving_time": 2225,
+    "total_elevation_gain": 4.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-04-24T06:34:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10760.6,
+    "moving_time": 3367,
+    "total_elevation_gain": 96.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-03-11T09:37:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14448.7,
+    "moving_time": 3745,
+    "total_elevation_gain": 34.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-30T09:29:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6415.5,
+    "moving_time": 3685,
+    "total_elevation_gain": 64.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-03T12:52:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3843.2,
+    "moving_time": 2148,
+    "total_elevation_gain": 15.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-09T12:46:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7515.6,
+    "moving_time": 7122,
+    "total_elevation_gain": 61.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-01-07T12:55:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3699.9,
+    "moving_time": 2864,
+    "total_elevation_gain": 17.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-10-21T06:06:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3306.6,
+    "moving_time": 2848,
+    "total_elevation_gain": 18.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-25T12:51:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7702.7,
+    "moving_time": 5457,
+    "total_elevation_gain": 66.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-18T09:33:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10525.3,
+    "moving_time": 3861,
+    "total_elevation_gain": 85.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-28T14:30:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5420.7,
+    "moving_time": 1932,
+    "total_elevation_gain": 17.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-10-03T13:58:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12324.8,
+    "moving_time": 4823,
+    "total_elevation_gain": 86.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-02-24T06:04:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5935.8,
+    "moving_time": 2289,
+    "total_elevation_gain": 36.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-09-05T14:37:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1349.5,
+    "moving_time": 919,
+    "total_elevation_gain": 3.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-01-20T13:45:06Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6067.6,
+    "moving_time": 4260,
+    "total_elevation_gain": 42.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-12-04T14:03:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2076.7,
+    "moving_time": 683,
+    "total_elevation_gain": 10.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-04-24T18:56:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7215.9,
+    "moving_time": 2208,
+    "total_elevation_gain": 57.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-09-13T06:14:54Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5552.9,
+    "moving_time": 2029,
+    "total_elevation_gain": 41.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-16T08:49:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6302.8,
+    "moving_time": 4531,
+    "total_elevation_gain": 28.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-07-05T14:09:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6815.2,
+    "moving_time": 7555,
+    "total_elevation_gain": 34.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-09-04T09:40:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4058.1,
+    "moving_time": 2316,
+    "total_elevation_gain": 24.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-14T12:06:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5315.1,
+    "moving_time": 5126,
+    "total_elevation_gain": 27.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-07-16T09:00:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5867.8,
+    "moving_time": 1528,
+    "total_elevation_gain": 24.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-13T06:11:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5743.1,
+    "moving_time": 4986,
+    "total_elevation_gain": 51.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-05T17:39:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7881.7,
+    "moving_time": 4380,
+    "total_elevation_gain": 58.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-01-12T08:49:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12921.2,
+    "moving_time": 4528,
+    "total_elevation_gain": 79.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-28T11:09:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6512.4,
+    "moving_time": 6765,
+    "total_elevation_gain": 34.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-02T18:44:16Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2827.1,
+    "moving_time": 725,
+    "total_elevation_gain": 21.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-15T13:48:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11295.2,
+    "moving_time": 2902,
+    "total_elevation_gain": 80.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-03-09T19:37:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8785.6,
+    "moving_time": 2966,
+    "total_elevation_gain": 63.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-02-19T06:25:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2863.3,
+    "moving_time": 1606,
+    "total_elevation_gain": 23.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-30T12:31:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4054.9,
+    "moving_time": 1559,
+    "total_elevation_gain": 35.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-24T11:39:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9958.7,
+    "moving_time": 2498,
+    "total_elevation_gain": 44.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-06-06T16:25:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6745.6,
+    "moving_time": 1725,
+    "total_elevation_gain": 19.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-10-17T08:03:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1032.1,
+    "moving_time": 658,
+    "total_elevation_gain": 5.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-05-07T18:18:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5503.5,
+    "moving_time": 1588,
+    "total_elevation_gain": 17.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-11-27T09:09:06Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10136.6,
+    "moving_time": 3535,
+    "total_elevation_gain": 69.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-13T06:01:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3451.8,
+    "moving_time": 3433,
+    "total_elevation_gain": 22.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-12-11T13:41:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5400.8,
+    "moving_time": 3801,
+    "total_elevation_gain": 26.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-17T19:35:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2540.2,
+    "moving_time": 1538,
+    "total_elevation_gain": 24.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-01-16T19:30:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12184.5,
+    "moving_time": 4642,
+    "total_elevation_gain": 87.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-28T17:37:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3494.3,
+    "moving_time": 1159,
+    "total_elevation_gain": 17.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-09-07T10:20:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11965.8,
+    "moving_time": 4052,
+    "total_elevation_gain": 58.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-03-22T07:35:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4502.4,
+    "moving_time": 1403,
+    "total_elevation_gain": 23.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-09-04T09:42:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3783.3,
+    "moving_time": 1216,
+    "total_elevation_gain": 22.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-04-22T16:58:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13585.4,
+    "moving_time": 5151,
+    "total_elevation_gain": 108.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-12-13T19:26:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2112.2,
+    "moving_time": 1297,
+    "total_elevation_gain": 5.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-02-14T06:38:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5629.9,
+    "moving_time": 2040,
+    "total_elevation_gain": 15.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-30T17:46:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8725.9,
+    "moving_time": 3372,
+    "total_elevation_gain": 83.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-01T08:55:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3670.7,
+    "moving_time": 1423,
+    "total_elevation_gain": 20.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-06-07T16:25:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2506.6,
+    "moving_time": 1895,
+    "total_elevation_gain": 20.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-06-05T12:15:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2644.9,
+    "moving_time": 993,
+    "total_elevation_gain": 21.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-10-27T16:18:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2745.9,
+    "moving_time": 840,
+    "total_elevation_gain": 20.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-02-25T11:24:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4548.2,
+    "moving_time": 4374,
+    "total_elevation_gain": 41.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-09-13T16:33:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3224.8,
+    "moving_time": 1167,
+    "total_elevation_gain": 20.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-11-06T10:30:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7299.4,
+    "moving_time": 4190,
+    "total_elevation_gain": 34.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-04T15:08:13Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7624.6,
+    "moving_time": 5960,
+    "total_elevation_gain": 66.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-09-10T16:37:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4035.0,
+    "moving_time": 1297,
+    "total_elevation_gain": 16.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-16T17:14:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3737.6,
+    "moving_time": 1103,
+    "total_elevation_gain": 32.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-05-24T19:42:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8547.2,
+    "moving_time": 2744,
+    "total_elevation_gain": 52.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-12-20T08:15:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1129.1,
+    "moving_time": 1029,
+    "total_elevation_gain": 8.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-14T19:46:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7499.4,
+    "moving_time": 5017,
+    "total_elevation_gain": 25.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-03-12T16:15:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2536.2,
+    "moving_time": 1413,
+    "total_elevation_gain": 10.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-06-24T17:18:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8232.2,
+    "moving_time": 2911,
+    "total_elevation_gain": 80.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-04-16T06:17:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14494.8,
+    "moving_time": 5474,
+    "total_elevation_gain": 121.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-01-04T06:24:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6046.1,
+    "moving_time": 2175,
+    "total_elevation_gain": 24.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-02-11T13:51:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9395.1,
+    "moving_time": 2691,
+    "total_elevation_gain": 86.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-26T15:37:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5108.2,
+    "moving_time": 4903,
+    "total_elevation_gain": 28.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-15T10:43:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1314.9,
+    "moving_time": 1344,
+    "total_elevation_gain": 10.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-01T14:46:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5610.1,
+    "moving_time": 1774,
+    "total_elevation_gain": 50.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-28T07:59:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1876.2,
+    "moving_time": 1484,
+    "total_elevation_gain": 8.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-11-27T16:03:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4912.6,
+    "moving_time": 4017,
+    "total_elevation_gain": 24.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-01T11:42:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1017.9,
+    "moving_time": 982,
+    "total_elevation_gain": 8.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-03-22T17:08:15Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6112.4,
+    "moving_time": 4690,
+    "total_elevation_gain": 46.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-01-29T17:50:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4485.2,
+    "moving_time": 2693,
+    "total_elevation_gain": 21.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-17T17:31:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7386.6,
+    "moving_time": 2541,
+    "total_elevation_gain": 35.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-26T15:35:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3663.7,
+    "moving_time": 943,
+    "total_elevation_gain": 34.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-04-30T16:23:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1200.1,
+    "moving_time": 1036,
+    "total_elevation_gain": 3.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-07-19T15:19:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1052.9,
+    "moving_time": 786,
+    "total_elevation_gain": 6.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-21T19:09:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5422.4,
+    "moving_time": 5466,
+    "total_elevation_gain": 43.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-21T17:57:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7228.0,
+    "moving_time": 2043,
+    "total_elevation_gain": 58.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-10-13T17:59:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7934.6,
+    "moving_time": 6189,
+    "total_elevation_gain": 42.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-08T13:34:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3327.5,
+    "moving_time": 3009,
+    "total_elevation_gain": 14.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-01T19:41:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1269.9,
+    "moving_time": 805,
+    "total_elevation_gain": 10.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-16T17:51:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7624.0,
+    "moving_time": 2275,
+    "total_elevation_gain": 48.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-01-21T14:04:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14595.5,
+    "moving_time": 3702,
+    "total_elevation_gain": 132.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-07-10T08:23:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4307.4,
+    "moving_time": 1227,
+    "total_elevation_gain": 21.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-08-03T18:19:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13651.8,
+    "moving_time": 4748,
+    "total_elevation_gain": 90.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-19T15:38:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8330.4,
+    "moving_time": 2239,
+    "total_elevation_gain": 70.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-03-10T17:55:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4513.9,
+    "moving_time": 3723,
+    "total_elevation_gain": 17.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-15T07:43:16Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4747.0,
+    "moving_time": 3851,
+    "total_elevation_gain": 20.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-03-04T07:23:37Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4265.1,
+    "moving_time": 3583,
+    "total_elevation_gain": 37.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-03T19:54:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6562.9,
+    "moving_time": 1788,
+    "total_elevation_gain": 27.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-05-23T07:56:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5476.1,
+    "moving_time": 1487,
+    "total_elevation_gain": 21.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-09-14T15:53:23Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12786.9,
+    "moving_time": 3731,
+    "total_elevation_gain": 33.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-31T11:52:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7458.0,
+    "moving_time": 1966,
+    "total_elevation_gain": 27.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-02-22T10:41:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3323.2,
+    "moving_time": 3674,
+    "total_elevation_gain": 28.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-03-30T10:59:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2030.7,
+    "moving_time": 1137,
+    "total_elevation_gain": 10.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-07-18T08:46:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13928.7,
+    "moving_time": 3492,
+    "total_elevation_gain": 78.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-22T14:00:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6275.5,
+    "moving_time": 5840,
+    "total_elevation_gain": 59.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-12-13T09:05:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4251.6,
+    "moving_time": 1233,
+    "total_elevation_gain": 16.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-10-20T08:41:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4044.2,
+    "moving_time": 4086,
+    "total_elevation_gain": 9.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-08-31T18:26:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1096.1,
+    "moving_time": 716,
+    "total_elevation_gain": 10.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-21T07:12:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12358.6,
+    "moving_time": 3615,
+    "total_elevation_gain": 112.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-22T17:57:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2723.0,
+    "moving_time": 895,
+    "total_elevation_gain": 6.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-29T15:09:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1541.8,
+    "moving_time": 931,
+    "total_elevation_gain": 14.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-08-21T12:41:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2671.0,
+    "moving_time": 922,
+    "total_elevation_gain": 23.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-25T17:28:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11996.6,
+    "moving_time": 3163,
+    "total_elevation_gain": 41.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-03T15:40:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2581.4,
+    "moving_time": 1666,
+    "total_elevation_gain": 14.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-06T16:48:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11243.1,
+    "moving_time": 2980,
+    "total_elevation_gain": 83.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-08-10T16:30:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2100.5,
+    "moving_time": 1307,
+    "total_elevation_gain": 16.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-11-19T19:34:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1018.9,
+    "moving_time": 595,
+    "total_elevation_gain": 4.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-07-10T12:09:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1771.9,
+    "moving_time": 1657,
+    "total_elevation_gain": 9.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-02-23T13:58:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7887.5,
+    "moving_time": 4942,
+    "total_elevation_gain": 54.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-05-07T14:23:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1838.3,
+    "moving_time": 1366,
+    "total_elevation_gain": 17.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-19T17:15:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3668.1,
+    "moving_time": 3840,
+    "total_elevation_gain": 7.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-01-22T07:44:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3505.0,
+    "moving_time": 1966,
+    "total_elevation_gain": 31.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-19T19:00:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11214.2,
+    "moving_time": 2873,
+    "total_elevation_gain": 95.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-04-08T12:15:15Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1472.0,
+    "moving_time": 843,
+    "total_elevation_gain": 7.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-15T16:20:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4624.9,
+    "moving_time": 1388,
+    "total_elevation_gain": 43.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-03-30T08:39:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4193.7,
+    "moving_time": 1223,
+    "total_elevation_gain": 40.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-07-24T06:22:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1194.0,
+    "moving_time": 671,
+    "total_elevation_gain": 11.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-10-21T07:30:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3920.8,
+    "moving_time": 3221,
+    "total_elevation_gain": 34.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-06T18:24:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3806.6,
+    "moving_time": 983,
+    "total_elevation_gain": 31.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-09-10T11:47:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11149.1,
+    "moving_time": 3534,
+    "total_elevation_gain": 78.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-24T13:05:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8973.9,
+    "moving_time": 3439,
+    "total_elevation_gain": 28.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-19T12:04:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6644.5,
+    "moving_time": 7080,
+    "total_elevation_gain": 32.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-11T14:01:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3761.1,
+    "moving_time": 2919,
+    "total_elevation_gain": 32.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-05-21T15:00:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8030.9,
+    "moving_time": 3089,
+    "total_elevation_gain": 16.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-22T08:40:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8628.3,
+    "moving_time": 2213,
+    "total_elevation_gain": 66.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-03-04T09:41:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7956.7,
+    "moving_time": 2439,
+    "total_elevation_gain": 66.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-05-05T17:38:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14502.7,
+    "moving_time": 4252,
+    "total_elevation_gain": 75.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-11-13T06:44:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7682.4,
+    "moving_time": 8132,
+    "total_elevation_gain": 41.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-23T14:50:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1717.3,
+    "moving_time": 1109,
+    "total_elevation_gain": 4.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-06-06T19:33:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3507.1,
+    "moving_time": 976,
+    "total_elevation_gain": 22.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-02-28T07:09:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1748.3,
+    "moving_time": 1932,
+    "total_elevation_gain": 16.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-05-28T14:05:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5662.9,
+    "moving_time": 5654,
+    "total_elevation_gain": 31.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-09-29T19:41:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4670.3,
+    "moving_time": 3467,
+    "total_elevation_gain": 36.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-28T08:47:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8149.1,
+    "moving_time": 2108,
+    "total_elevation_gain": 62.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-02-21T11:34:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2309.8,
+    "moving_time": 1328,
+    "total_elevation_gain": 10.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-07-13T14:54:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2191.9,
+    "moving_time": 583,
+    "total_elevation_gain": 18.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-09-21T13:17:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2703.6,
+    "moving_time": 1837,
+    "total_elevation_gain": 16.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-12-24T19:32:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4905.1,
+    "moving_time": 3108,
+    "total_elevation_gain": 43.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-02T11:55:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12454.7,
+    "moving_time": 3290,
+    "total_elevation_gain": 101.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-05-22T15:03:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3096.4,
+    "moving_time": 1848,
+    "total_elevation_gain": 20.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-22T13:19:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4383.6,
+    "moving_time": 1536,
+    "total_elevation_gain": 28.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-08-30T18:25:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2113.2,
+    "moving_time": 1200,
+    "total_elevation_gain": 9.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-03-05T06:15:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5611.2,
+    "moving_time": 1484,
+    "total_elevation_gain": 20.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-12-08T06:05:48Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4551.7,
+    "moving_time": 1207,
+    "total_elevation_gain": 45.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-04-08T17:32:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9740.8,
+    "moving_time": 2711,
+    "total_elevation_gain": 45.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-01-18T11:03:03Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7487.5,
+    "moving_time": 4471,
+    "total_elevation_gain": 40.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-09-09T09:51:24Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3652.3,
+    "moving_time": 1344,
+    "total_elevation_gain": 17.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-11T10:13:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7102.2,
+    "moving_time": 4940,
+    "total_elevation_gain": 55.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-31T19:11:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4470.7,
+    "moving_time": 2851,
+    "total_elevation_gain": 18.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-23T13:12:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1360.5,
+    "moving_time": 1061,
+    "total_elevation_gain": 9.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-02-03T11:21:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2203.4,
+    "moving_time": 858,
+    "total_elevation_gain": 15.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-09-14T17:14:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3080.5,
+    "moving_time": 2639,
+    "total_elevation_gain": 28.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-31T10:43:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1958.4,
+    "moving_time": 1696,
+    "total_elevation_gain": 19.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-08-17T06:26:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13104.2,
+    "moving_time": 3597,
+    "total_elevation_gain": 74.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-01-19T18:18:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5120.6,
+    "moving_time": 3128,
+    "total_elevation_gain": 42.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-02-04T09:18:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7817.3,
+    "moving_time": 2075,
+    "total_elevation_gain": 38.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-09-08T09:22:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7406.1,
+    "moving_time": 5225,
+    "total_elevation_gain": 62.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-09-05T18:51:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5283.6,
+    "moving_time": 2056,
+    "total_elevation_gain": 31.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-23T06:01:27Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4343.7,
+    "moving_time": 2487,
+    "total_elevation_gain": 25.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-26T09:26:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11789.0,
+    "moving_time": 4623,
+    "total_elevation_gain": 83.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-07-19T13:07:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1698.9,
+    "moving_time": 960,
+    "total_elevation_gain": 7.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-11-30T13:59:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12435.6,
+    "moving_time": 4266,
+    "total_elevation_gain": 110.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-08-07T06:05:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 14070.6,
+    "moving_time": 3674,
+    "total_elevation_gain": 78.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-04-16T10:34:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7206.7,
+    "moving_time": 2153,
+    "total_elevation_gain": 23.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-13T17:45:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1033.7,
+    "moving_time": 685,
+    "total_elevation_gain": 7.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-09-22T18:59:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4636.1,
+    "moving_time": 3254,
+    "total_elevation_gain": 24.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-12-03T14:02:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5278.5,
+    "moving_time": 1509,
+    "total_elevation_gain": 30.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-04-06T16:19:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6180.9,
+    "moving_time": 6219,
+    "total_elevation_gain": 47.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-04-23T18:57:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5819.0,
+    "moving_time": 4541,
+    "total_elevation_gain": 21.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-30T16:50:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2053.2,
+    "moving_time": 775,
+    "total_elevation_gain": 14.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-08T10:55:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3758.9,
+    "moving_time": 1479,
+    "total_elevation_gain": 31.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-14T14:22:01Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7265.3,
+    "moving_time": 6709,
+    "total_elevation_gain": 23.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-03-21T08:31:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12762.9,
+    "moving_time": 3897,
+    "total_elevation_gain": 99.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-04-08T15:01:34Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12665.0,
+    "moving_time": 4162,
+    "total_elevation_gain": 119.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-05-15T19:27:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1679.6,
+    "moving_time": 1696,
+    "total_elevation_gain": 10.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-22T09:28:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2930.2,
+    "moving_time": 792,
+    "total_elevation_gain": 9.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-09T09:10:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2966.0,
+    "moving_time": 1860,
+    "total_elevation_gain": 26.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-08-03T07:53:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4137.2,
+    "moving_time": 1039,
+    "total_elevation_gain": 39.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-12-10T09:33:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5092.0,
+    "moving_time": 1442,
+    "total_elevation_gain": 19.0,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-10-28T17:34:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4873.4,
+    "moving_time": 4962,
+    "total_elevation_gain": 45.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-12-13T12:49:33Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9647.1,
+    "moving_time": 2464,
+    "total_elevation_gain": 26.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-05T07:31:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1532.4,
+    "moving_time": 1661,
+    "total_elevation_gain": 13.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-03-22T06:25:17Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7396.0,
+    "moving_time": 5414,
+    "total_elevation_gain": 19.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-01-31T13:16:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10379.1,
+    "moving_time": 2722,
+    "total_elevation_gain": 54.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-12-08T12:32:50Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5484.5,
+    "moving_time": 6029,
+    "total_elevation_gain": 25.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-08-10T18:12:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11068.6,
+    "moving_time": 3688,
+    "total_elevation_gain": 39.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-03-29T09:13:18Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5580.4,
+    "moving_time": 2044,
+    "total_elevation_gain": 30.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-06-28T16:49:15Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7691.4,
+    "moving_time": 5172,
+    "total_elevation_gain": 28.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-10-06T11:16:15Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11225.7,
+    "moving_time": 4033,
+    "total_elevation_gain": 72.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-12-02T13:14:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3728.4,
+    "moving_time": 3275,
+    "total_elevation_gain": 24.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-12T10:06:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7782.2,
+    "moving_time": 2397,
+    "total_elevation_gain": 22.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-24T16:20:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1807.8,
+    "moving_time": 1324,
+    "total_elevation_gain": 10.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-04-18T06:37:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7640.1,
+    "moving_time": 5945,
+    "total_elevation_gain": 70.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-06-29T17:48:55Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9098.2,
+    "moving_time": 3172,
+    "total_elevation_gain": 20.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-05-10T15:25:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5857.9,
+    "moving_time": 4215,
+    "total_elevation_gain": 52.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-07-01T09:09:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7422.9,
+    "moving_time": 6339,
+    "total_elevation_gain": 41.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-11-09T15:43:19Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7072.2,
+    "moving_time": 7355,
+    "total_elevation_gain": 19.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-03-02T14:23:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7310.2,
+    "moving_time": 5103,
+    "total_elevation_gain": 40.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-07-10T17:20:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8729.7,
+    "moving_time": 3053,
+    "total_elevation_gain": 52.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-10-25T13:03:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2847.3,
+    "moving_time": 1726,
+    "total_elevation_gain": 14.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-05-05T07:16:57Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10675.7,
+    "moving_time": 3188,
+    "total_elevation_gain": 106.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-05-07T06:28:07Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3779.7,
+    "moving_time": 1011,
+    "total_elevation_gain": 21.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-04-25T06:35:35Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2970.1,
+    "moving_time": 2116,
+    "total_elevation_gain": 24.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-08-26T16:48:10Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6777.3,
+    "moving_time": 2568,
+    "total_elevation_gain": 45.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-09-28T06:36:20Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6253.1,
+    "moving_time": 5969,
+    "total_elevation_gain": 33.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-08-04T11:01:25Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7546.7,
+    "moving_time": 2325,
+    "total_elevation_gain": 37.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-06-13T19:46:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13534.7,
+    "moving_time": 3545,
+    "total_elevation_gain": 120.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-23T07:49:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6811.9,
+    "moving_time": 7523,
+    "total_elevation_gain": 57.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-06-24T12:10:30Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6944.4,
+    "moving_time": 1748,
+    "total_elevation_gain": 23.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-12-20T11:57:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6497.0,
+    "moving_time": 1627,
+    "total_elevation_gain": 18.3,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-09-17T19:51:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3180.9,
+    "moving_time": 1147,
+    "total_elevation_gain": 11.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-11-09T10:24:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3708.3,
+    "moving_time": 3894,
+    "total_elevation_gain": 19.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-10-27T19:01:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10101.0,
+    "moving_time": 2577,
+    "total_elevation_gain": 49.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-03-03T10:55:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9161.2,
+    "moving_time": 3225,
+    "total_elevation_gain": 85.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-09-29T19:53:04Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9733.1,
+    "moving_time": 2917,
+    "total_elevation_gain": 60.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-06-22T12:29:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12502.2,
+    "moving_time": 4685,
+    "total_elevation_gain": 121.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-08-24T13:44:26Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8225.8,
+    "moving_time": 2415,
+    "total_elevation_gain": 61.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-04-09T18:26:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11334.0,
+    "moving_time": 3428,
+    "total_elevation_gain": 108.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-07-10T15:39:43Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1373.6,
+    "moving_time": 854,
+    "total_elevation_gain": 5.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-04-02T14:07:14Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12423.1,
+    "moving_time": 3393,
+    "total_elevation_gain": 71.9,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-10-22T19:33:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4230.4,
+    "moving_time": 4119,
+    "total_elevation_gain": 36.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-03-13T08:00:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3542.7,
+    "moving_time": 2054,
+    "total_elevation_gain": 15.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-10-22T09:19:56Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4417.1,
+    "moving_time": 2470,
+    "total_elevation_gain": 20.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-01-21T17:31:16Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 9577.2,
+    "moving_time": 3608,
+    "total_elevation_gain": 91.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-03-02T15:09:46Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7754.4,
+    "moving_time": 2220,
+    "total_elevation_gain": 47.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-11-27T15:35:32Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8869.1,
+    "moving_time": 2865,
+    "total_elevation_gain": 27.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-01-12T19:26:54Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10477.6,
+    "moving_time": 3939,
+    "total_elevation_gain": 45.4,
+    "type": "Run"
+  },
+  {
+    "start_date": "2024-01-11T18:49:44Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8642.9,
+    "moving_time": 2553,
+    "total_elevation_gain": 59.2,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-04-26T10:19:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4898.4,
+    "moving_time": 3333,
+    "total_elevation_gain": 14.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-12-07T19:26:51Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6711.8,
+    "moving_time": 1774,
+    "total_elevation_gain": 18.1,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-01-19T17:00:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7452.3,
+    "moving_time": 2427,
+    "total_elevation_gain": 23.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-04-16T12:08:12Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 3297.8,
+    "moving_time": 2903,
+    "total_elevation_gain": 14.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-12-23T08:13:02Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5511.4,
+    "moving_time": 4261,
+    "total_elevation_gain": 26.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-17T14:15:09Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10684.9,
+    "moving_time": 4172,
+    "total_elevation_gain": 95.8,
+    "type": "Run"
+  },
+  {
+    "start_date": "2021-07-22T16:51:22Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1130.9,
+    "moving_time": 658,
+    "total_elevation_gain": 3.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-08-31T09:44:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 10544.3,
+    "moving_time": 3840,
+    "total_elevation_gain": 78.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-06-04T17:56:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6898.3,
+    "moving_time": 7138,
+    "total_elevation_gain": 63.6,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-07-07T08:51:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2936.4,
+    "moving_time": 1950,
+    "total_elevation_gain": 12.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-05-22T08:04:53Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1563.0,
+    "moving_time": 1623,
+    "total_elevation_gain": 6.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-02-23T12:31:15Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2443.2,
+    "moving_time": 903,
+    "total_elevation_gain": 11.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2022-02-11T13:07:58Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 13766.3,
+    "moving_time": 4812,
+    "total_elevation_gain": 101.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-05-31T14:46:21Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2642.7,
+    "moving_time": 1600,
+    "total_elevation_gain": 14.0,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2020-05-28T15:57:06Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 7179.0,
+    "moving_time": 7062,
+    "total_elevation_gain": 25.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-02-05T15:54:42Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8177.1,
+    "moving_time": 2722,
+    "total_elevation_gain": 34.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-03-30T07:04:38Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 12222.0,
+    "moving_time": 3355,
+    "total_elevation_gain": 82.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-11-03T17:10:00Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6569.0,
+    "moving_time": 4108,
+    "total_elevation_gain": 40.3,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-10-15T06:47:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2872.2,
+    "moving_time": 1695,
+    "total_elevation_gain": 20.4,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-02T12:13:49Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2827.1,
+    "moving_time": 1597,
+    "total_elevation_gain": 24.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-10-31T07:41:40Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2794.6,
+    "moving_time": 2704,
+    "total_elevation_gain": 14.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-08-19T13:13:47Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 11626.6,
+    "moving_time": 4400,
+    "total_elevation_gain": 111.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-01-12T07:49:36Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2077.9,
+    "moving_time": 735,
+    "total_elevation_gain": 11.7,
+    "type": "Run"
+  },
+  {
+    "start_date": "2020-10-18T17:28:39Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5906.9,
+    "moving_time": 5147,
+    "total_elevation_gain": 56.5,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2025-04-25T08:57:29Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6480.6,
+    "moving_time": 4759,
+    "total_elevation_gain": 19.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2022-07-28T06:18:59Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1969.7,
+    "moving_time": 1991,
+    "total_elevation_gain": 9.2,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-06-29T14:43:28Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 4839.1,
+    "moving_time": 3564,
+    "total_elevation_gain": 43.9,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-08-26T14:00:11Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 6376.0,
+    "moving_time": 5196,
+    "total_elevation_gain": 37.7,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2021-07-11T16:00:41Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5592.2,
+    "moving_time": 1652,
+    "total_elevation_gain": 17.5,
+    "type": "Run"
+  },
+  {
+    "start_date": "2025-03-05T11:45:45Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 5162.3,
+    "moving_time": 5452,
+    "total_elevation_gain": 12.8,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2024-04-27T06:14:08Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 1480.2,
+    "moving_time": 1062,
+    "total_elevation_gain": 12.1,
+    "type": "Walk"
+  },
+  {
+    "start_date": "2023-04-13T16:50:31Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 8181.6,
+    "moving_time": 3193,
+    "total_elevation_gain": 70.6,
+    "type": "Run"
+  },
+  {
+    "start_date": "2023-06-30T11:31:52Z",
+    "average_watts": null,
+    "average_speed": null,
+    "distance": 2125.7,
+    "moving_time": 1270,
+    "total_elevation_gain": 19.4,
+    "type": "Walk"
   }
 ]

--- a/app/views/chart.tpl
+++ b/app/views/chart.tpl
@@ -185,6 +185,37 @@
       max-width: auto;
       max-height: 25px;
     }
+
+    .activity-toggle {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      margin-bottom: 10px;
+      flex-wrap: wrap;
+    }
+
+    .activity-btn {
+      padding: 10px 18px;
+      border: none;
+      border-radius: 20px;
+      background-color: #eee;
+      color: #333;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+      font-family: 'Quicksand', sans-serif;
+    }
+
+    .activity-btn:hover {
+      background-color: #ddd;
+      transform: translateY(-1px);
+    }
+
+    .activity-btn.active {
+      background-color: #e87722;
+      color: #fff;
+    }
   </style>
 </head>
 
@@ -194,6 +225,28 @@
     <h1>3thirty Charts for Strava</h1>
     <h2>Turn workouts into trends with time-based performance insights</h2>
   </header>
+
+  <div class="activity-toggle">
+    <button class="activity-btn active" data-activity="run">🏃 Run</button>
+    <button class="activity-btn" data-activity="ride">🚴 Ride</button>
+    <button class="activity-btn" data-activity="walk">🚶 Walk</button>
+  </div>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const activityButtons = document.querySelectorAll('.activity-btn');
+
+      activityButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          activityButtons.forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+
+          const selectedActivity = btn.dataset.activity;
+          // TODO: update metric dropdown based on selectedActivity
+        });
+      });
+    });
+  </script>
 
   <div class="filters">
   <div class="filter-group">
@@ -229,6 +282,16 @@
     document.getElementById("metric").value = currentMetric;
     document.getElementById("period").value = currentPeriod;
 
+    const urlParams = new URLSearchParams(window.location.search);
+    const currentSport = urlParams.get('sport');
+
+    if (currentSport) {
+      const activeBtn = document.querySelector(`.activity-btn[data-activity="${currentSport}"]`);
+      if (activeBtn) {
+        document.querySelectorAll('.activity-btn').forEach(b => b.classList.remove('active'));
+        activeBtn.classList.add('active');
+      }
+    }
 
     // change the view when the button is clicked
     document.getElementById("updateBtn").addEventListener("click", () => {
@@ -236,9 +299,12 @@
       const metric = document.getElementById("metric").value;
       const period = document.getElementById("period").value;
 
+      const sport = document.querySelector('.activity-btn.active')?.dataset.activity;
+      const query_string = sport ? `?sport=${sport}` : ''
+
       const basePath = window.location.pathname.split('/').slice(0, 2).join('/');
   
-      const path = `${basePath}/${type}/${metric}/${period}`;
+      const path = `${basePath}/${type}/${metric}/${period}${query_string}`;
       window.location.href = path;
     });
   </script>


### PR DESCRIPTION
Currently, we fetch data for all sports (`types`) from strava and include activities from all sports in the chart. This can lead to strange data (e.g. averaging distance across rides and walks).

This PR introduces sports filtering for: walk, run and ride. Only activities for the selected sport will be included in the chart. If `sport` is omitted, the current behavior is maintained